### PR TITLE
added operator and password controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:17-alpine
+COPY build/libs/*.jar /app/
+WORKDIR /app/
+RUN mv /app/*.jar /app/app.jar
+ENTRYPOINT ["java"]
+CMD ["-jar", "/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.3'
+services:
+  user-ms-db:
+    image: postgres
+    ports:
+      - "9003:5432"
+    volumes:
+      - db_data_user:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: 123456
+      POSTGRES_DB: user-ms
+
+volumes:
+  db_data_user: {}

--- a/user-ms/src/main/java/az/ingress/userms/controller/OperatorController.java
+++ b/user-ms/src/main/java/az/ingress/userms/controller/OperatorController.java
@@ -1,4 +1,31 @@
 package az.ingress.userms.controller;
 
+import az.ingress.userms.model.dto.request.OperatorRequestDto;
+import az.ingress.userms.service.OperatorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/operators")
 public class OperatorController {
+    private final OperatorService operatorService;
+    @PutMapping("/register")
+    public ResponseEntity<Void> register(@RequestBody OperatorRequestDto dto) {
+        operatorService.registerOperator(dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/admin/operator/approval")
+    public ResponseEntity<Void> approvalOperator(@RequestBody OperatorRequestDto dto) {
+        operatorService.approvalOperator(dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/admin/operator/remove")
+    public ResponseEntity<Void> removeOperator(@RequestBody OperatorRequestDto dto) {
+        operatorService.removeOperatorRole(dto);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/user-ms/src/main/java/az/ingress/userms/controller/PasswordController.java
+++ b/user-ms/src/main/java/az/ingress/userms/controller/PasswordController.java
@@ -1,4 +1,31 @@
 package az.ingress.userms.controller;
 
+import az.ingress.userms.model.dto.ChangePasswordDto;
+import az.ingress.userms.model.dto.ResetPasswordDto;
+import az.ingress.userms.service.PasswordService;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user/password")
 public class PasswordController {
+    private final PasswordService passwordService;
+
+    @PutMapping("/change")
+    public ResponseEntity<Void> changePassword(@RequestBody @Valid ChangePasswordDto dto,
+                                               @RequestHeader(value = "Authorization") String token,
+                                               HttpServletResponse response) {
+        passwordService.changePassword(dto, token, response);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/reset")
+    public ResponseEntity<Void> setNewPassword(@RequestParam String token, @RequestBody @Valid ResetPasswordDto passwordDto) {
+        passwordService.setNewPassword(token, passwordDto);
+        return ResponseEntity.ok().build();
+    }
 }


### PR DESCRIPTION
Summary

Add Operator actions and Password flows; update Docker config.

Endpoints

OperatorController (/api/v1/operators)

PUT /register – register operator

PATCH /admin/operator/approval – approve operator

PATCH /admin/operator/remove – remove operator role

PasswordController (/api/v1/user/password)

PUT /change – change password (requires Authorization header)

PUT /reset?token=... – set new password with reset token

Infra / Docker

Updated Docker image/env vars (app port & profiles), rebuilt image, and adjusted compose/service config to reflect new controllers.

How to test (quick)

# Change password (authorized)
curl -X PUT 'http://localhost:8080/api/v1/user/password/change' \
 -H 'Authorization: Bearer <JWT>' -H 'Content-Type: application/json' \
 -d '{"oldPassword":"OldP@ss1","newPassword":"NewP@ssw0rd"}'

# Reset with token
curl -X PUT 'http://localhost:8080/api/v1/user/password/reset?token=<RESET_TOKEN>' \
 -H 'Content-Type: application/json' -d '{"newPassword":"NewP@ssw0rd"}'

# Register operator
curl -X PUT 'http://localhost:8080/api/v1/operators/register' \
 -H 'Content-Type: application/json' -d '{...}'

# Approve / Remove role
curl -X PATCH 'http://localhost:8080/api/v1/operators/admin/operator/approval' -d '{...}'
curl -X PATCH 'http://localhost:8080/api/v1/operators/admin/operator/remove' -d '{...}'
