### PR TITLE
feat(model): add Flight, Dto, Enums entities and mappings

### DIFF
--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/FlightDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/FlightDto.java
@@ -1,0 +1,28 @@
+package az.ingress.flightms.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import ingress.flightms.model.dto.response.PlaneResponseDTO;
+import ingress.flightms.model.enums.ApprovalState;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FlightDto {
+    Long id;
+    String from;
+    String to;
+    BigDecimal price;
+    Integer ticketCount;
+    LocalDateTime departureTime;
+    LocalDateTime arrivalTime;
+    String feedbackMessage;
+    ApprovalState approvalState;
+    PlaneResponseDTO planeDetails;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/FlightDtoByCreatedOperator.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/FlightDtoByCreatedOperator.java
@@ -1,0 +1,20 @@
+package az.ingress.flightms.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FlightDtoByCreatedOperator {
+    Long operatorId;
+    String operatorName;
+    String operatorSurname;
+    String operatorEmail;
+    FlightDto flightDto;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/AirlineDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/AirlineDto.java
@@ -1,0 +1,16 @@
+package az.ingress.flightms.model.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class AirlineDto {
+    @NotBlank(message = "Airline name cannot be blank")
+    @NotNull(message = "Airline name is required")
+    String name;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/FlightPlanePlaceDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/FlightPlanePlaceDto.java
@@ -1,0 +1,23 @@
+package az.ingress.flightms.model.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FlightPlanePlaceDto {
+    @NotNull
+    private Long flightId;
+    @NotNull
+    private Long planePlaceId;
+    @NotNull
+    private Long ticketId;
+    @NotBlank
+    private String placeStatus;
+    @NotBlank
+    private String message;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/FlightRequestDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/FlightRequestDto.java
@@ -1,0 +1,39 @@
+package az.ingress.flightms.model.dto.request;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+//@ValidFlightTimes
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class FlightRequestDto {
+
+//    @ValidAirportCode(message = "Invalid departure airport code")
+    String from;
+
+//    @ValidAirportCode(message = "Invalid destination airport code")
+    String to;
+
+    @NotNull(message = "Price is required")
+    @DecimalMin(value = "0.0", inclusive = false, message = "Price must be positive")
+    BigDecimal price;
+
+    @NotNull(message = "Departure time is required")
+    LocalDateTime departureTime;
+
+    @NotNull(message = "Arrival time is required")
+    LocalDateTime arrivalTime;
+
+    @NotNull(message = "Plane ID is required")
+    Long planeId;
+
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/PlanePlaceRequest.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/PlanePlaceRequest.java
@@ -1,0 +1,15 @@
+package az.ingress.flightms.model.dto.request;
+
+
+import az.ingress.flightms.model.enums.PlaceType;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PlanePlaceRequest {
+    private Integer place;    // optional when creating a new plane place
+    private Integer row;     // optional when creating a new plane place
+    private Integer placeNumber;
+    private PlaceType placeType;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/PlaneRequestDTO.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/PlaneRequestDTO.java
@@ -1,0 +1,18 @@
+package az.ingress.flightms.model.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PlaneRequestDTO {
+    private String name;
+    private Long airlineId;
+    private Set<Long> planePlacesIds;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/TicketConfirmationRequestDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/TicketConfirmationRequestDto.java
@@ -1,0 +1,6 @@
+package az.ingress.flightms.model.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record TicketConfirmationRequestDto(@NotNull Long ticketId,@NotNull String creditCardNo,@NotNull String creditCardName,@NotNull String creditCardExpiry,@NotNull String creditCardCvc) {
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/TicketCreateRequestDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/TicketCreateRequestDto.java
@@ -1,0 +1,7 @@
+package az.ingress.flightms.model.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+
+public record TicketCreateRequestDto(@NotNull String passengerName, @NotNull String passengerSurname, @NotNull String passportNo, @NotNull String email, @NotNull String phone, @NotNull Long ticketRequestId) {
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/TicketCreateResponseDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/TicketCreateResponseDto.java
@@ -1,0 +1,4 @@
+package az.ingress.flightms.model.dto.request;
+
+public record TicketCreateResponseDto(Long createdTicketId) {
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/TicketRequestDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/request/TicketRequestDto.java
@@ -1,0 +1,4 @@
+package az.ingress.flightms.model.dto.request;
+
+public record TicketRequestDto(Long flightId, Long planePlaceId) {
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/AirlineResponseDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/AirlineResponseDto.java
@@ -1,0 +1,15 @@
+package az.ingress.flightms.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AirlineResponseDto {
+    private String name;
+    private Long id;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/BookingSearchResponseDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/BookingSearchResponseDto.java
@@ -1,0 +1,21 @@
+package az.ingress.flightms.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BookingSearchResponseDto {
+    private Long flightId;
+    private String from;
+    private String to;
+    private LocalDateTime date;
+    private BigDecimal price;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/FlightPlanePlaceDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/FlightPlanePlaceDto.java
@@ -1,0 +1,16 @@
+package az.ingress.flightms.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FlightPlanePlaceDto {
+    private Long id;
+    private Long flightId;
+    private Long planePlaceId;
+    private Long ticketId;
+    private String placeStatus;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/FlightResponseDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/FlightResponseDto.java
@@ -1,0 +1,23 @@
+package az.ingress.flightms.model.dto.response;
+
+
+import az.ingress.flightms.model.enums.Airport;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+public class FlightResponseDto {
+    private Airport from;
+    private Airport to;
+    private BigDecimal price;
+    private Integer ticketCount;
+    private LocalDateTime departureTime;
+    private LocalDateTime arrivalTime;
+    private List<Map<String,Object>> availableSeats;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/PlanePlaceResponse.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/PlanePlaceResponse.java
@@ -1,0 +1,18 @@
+package az.ingress.flightms.model.dto.response;
+import az.ingress.flightms.model.enums.PlaceType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PlanePlaceResponse {
+     private Long id;
+     private Integer place;
+     private Integer row;
+     private Integer placeNumber;
+     private PlaceType placeType;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/PlaneResponseDTO.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/PlaneResponseDTO.java
@@ -1,0 +1,23 @@
+package az.ingress.flightms.model.dto.response;
+
+import az.ingress.flightms.model.dto.AirlineDto;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PlaneResponseDTO {
+    private Long id;
+    private String name;
+    private Integer capacity;
+    private AirlineDto airline;
+    private Set<PlanePlaceResponse> planePlaces;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/TicketConfirmationResponseDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/TicketConfirmationResponseDto.java
@@ -1,0 +1,10 @@
+package az.ingress.flightms.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@AllArgsConstructor
+@Data
+public class TicketConfirmationResponseDto {
+    private final String createdTicketUrl;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/TicketResponseDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/TicketResponseDto.java
@@ -1,0 +1,4 @@
+package az.ingress.flightms.model.dto.response;
+
+public record TicketResponseDto(Long createdTicketRequestId) {
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/entity/Airline.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/entity/Airline.java
@@ -1,0 +1,18 @@
+package az.ingress.flightms.model.entity;
+
+
+import az.ingress.common.model.entity.AbstractEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class Airline extends AbstractEntity {
+    @Column(unique = true)
+    String name;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/entity/Flight.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/entity/Flight.java
@@ -1,0 +1,47 @@
+package az.ingress.flightms.model.entity;
+import az.ingress.common.model.entity.AbstractEntity;
+import az.ingress.flightms.model.enums.Airport;
+import az.ingress.flightms.model.enums.ApprovalState;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Nationalized;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@SQLRestriction("status = true")
+@DynamicUpdate
+public class Flight extends AbstractEntity {
+
+    @Column(name = "\"from\"")
+    @Enumerated(EnumType.STRING)
+    private Airport from;
+
+    @Column(name = "\"to\"")
+    @Enumerated(EnumType.STRING)
+    private Airport to;
+
+    private BigDecimal price;
+    private Integer ticketCount;
+    private LocalDateTime departureTime;
+    private LocalDateTime arrivalTime;
+    @Column(name = "feedback_message", length = 1000)
+    @Nationalized
+    private String feedbackMessage;
+    @ManyToOne
+    private Plane plane;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "approval_state")
+    private ApprovalState approvalState;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/entity/FlightPlanePlace.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/entity/FlightPlanePlace.java
@@ -1,0 +1,31 @@
+package az.ingress.flightms.model.entity;
+import az.ingress.common.model.entity.AbstractEntity;
+import az.ingress.flightms.model.enums.PlaceStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@SQLRestriction("status = true")
+@SuperBuilder
+public class FlightPlanePlace extends AbstractEntity {
+    @ManyToOne
+    private Flight flight;
+    @ManyToOne
+    private PlanePlace planePlace;
+    @ManyToOne
+    private Ticket ticket;
+    @Enumerated(EnumType.STRING)
+    private PlaceStatus placeStatus;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/entity/Plane.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/entity/Plane.java
@@ -1,0 +1,26 @@
+package az.ingress.flightms.model.entity;
+import az.ingress.common.model.entity.AbstractEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Set;
+
+@Entity
+@Getter
+@Setter
+@EqualsAndHashCode(of = "id")
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder
+public class Plane extends AbstractEntity {
+    private String name;
+    private Integer capacity;
+    @ManyToOne
+    private Airline airline;
+    @ManyToMany
+    private Set<PlanePlace> planePlaces;
+
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/entity/PlanePlace.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/entity/PlanePlace.java
@@ -1,0 +1,27 @@
+package az.ingress.flightms.model.entity;
+
+import az.ingress.common.model.entity.AbstractEntity;
+import az.ingress.flightms.model.enums.PlaceType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlanePlace extends AbstractEntity {
+    private Integer place; // optional when creating a new plane place
+    private Integer row; // optional when creating a new plane place
+    @Column(nullable = false)
+    private Integer placeNumber;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PlaceType placeType;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/entity/Ticket.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/entity/Ticket.java
@@ -1,0 +1,30 @@
+package az.ingress.flightms.model.entity;
+import az.ingress.common.model.entity.AbstractEntity;
+import az.ingress.flightms.model.enums.TicketStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder
+public class Ticket extends AbstractEntity {
+    private String ticketNo;
+    private String passengerName;
+    private String passengerSurname;
+    private String email;
+    private String phone;
+    private Long boughtUserId;
+    @Enumerated(EnumType.STRING)
+    private TicketStatus ticketStatus;
+    @ManyToOne
+    private Flight flight;
+    @OneToOne
+    private TicketRequest ticketRequest;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/entity/TicketRequest.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/entity/TicketRequest.java
@@ -1,0 +1,22 @@
+package az.ingress.flightms.model.entity;
+
+import az.ingress.common.model.entity.AbstractEntity;
+import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TicketRequest extends AbstractEntity {
+    private Long createdUserId;
+    private Long flightId;
+    private Long planePlaceId;
+    private LocalDateTime expiredDate;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/enums/Airport.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/enums/Airport.java
@@ -1,0 +1,58 @@
+package az.ingress.flightms.model.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public enum Airport {
+    GYD("Baku", "Azerbaijan"),
+    JFK("New York", "USA"),
+    LHR("London", "UK"),
+    ATL("Atlanta", "USA"),
+    PEK("Beijing", "China"),
+    DXB("Dubai", "UAE"),
+    LAX("Los Angeles", "USA"),
+    ORD("Chicago", "USA"),
+    CDG("Paris", "France"),
+    AMS("Amsterdam", "Netherlands"),
+    HND("Tokyo", "Japan"),
+    SYD("Sydney", "Australia"),
+    ICN("Seoul", "South Korea"),
+    SIN("Singapore", "Singapore"),
+    FRA("Frankfurt", "Germany"),
+    DEL("Delhi", "India"),
+    MUC("Munich", "Germany"),
+    YYZ("Toronto", "Canada"),
+    MAD("Madrid", "Spain"),
+    GRU("São Paulo", "Brazil"),
+    IST("Istanbul", "Turkey"),
+    BKK("Bangkok", "Thailand"),
+    HKG("Hong Kong", "Hong Kong"),
+    MEX("Mexico City", "Mexico"),
+    EZE("Buenos Aires", "Argentina"),
+    JNB("Johannesburg", "South Africa"),
+    SFO("San Francisco", "USA"),
+    ZRH("Zurich", "Switzerland"),
+    DME("Moscow", "Russia")
+    ;
+
+    private final String city;
+    private final String country;
+
+    public static List<Airport> findByCity(String city) {
+        return Arrays.stream(values())
+                .filter(airport -> airport.getCity().toLowerCase().contains(city.toLowerCase()))
+                .toList();
+    }
+
+    public static List<Airport> findByCountry(String country) {
+        return Arrays.stream(values())
+                .filter(airport -> airport.getCountry().toLowerCase().contains(country.toLowerCase()))
+                .toList();
+    }
+
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/enums/ApprovalState.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/enums/ApprovalState.java
@@ -1,0 +1,7 @@
+package az.ingress.flightms.model.enums;
+
+public enum ApprovalState {
+    PENDING,
+    APPROVED,
+    REJECTED;
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/enums/Exceptions.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/enums/Exceptions.java
@@ -1,0 +1,41 @@
+package az.ingress.flightms.model.enums;
+
+
+import az.ingress.common.model.exception.AbstractException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum Exceptions implements AbstractException {
+    NOT_FOUND("exception.not.found", "exception.not.found.detail", HttpStatus.NOT_FOUND),
+    FLIGHT_NOT_FOUND("exception.flight.not.found", "exception.flight.not.found.detail", HttpStatus.NOT_FOUND),
+    PLANE_NOT_FOUND("exception.plane.not.found", "exception.plane.not.found.detail", HttpStatus.NOT_FOUND),
+    PLANE_PLACES_NOT_FOUND("exception.plane.place.not.found", "exception.plane.place.not.found.detail", HttpStatus.NOT_FOUND),
+    STATE_IS_NOT_PENDING("exception.flight.not.pending.state", "exception.flight.not.pending.state.detail", HttpStatus.CONFLICT),
+    TICKET_IS_NOT_REFUNDABLE("exception.ticket.not.refundable", "exception.ticket.not.refundable.detail", HttpStatus.CONFLICT),
+    TICKET_REQUEST_ALREADY_USED("exception.ticket.request.already.used", "exception.ticket.request.already.used.detail", HttpStatus.BAD_REQUEST),
+    SOMETHING_WENT_WRONG("exception.something.went.wrong", "exception.something.went.wrong.detail", HttpStatus.INTERNAL_SERVER_ERROR),
+    UNAUTHORIZED("exception.unauthorized", "exception.unauthorized.detail", HttpStatus.UNAUTHORIZED),
+    UNIQUE_CONSTRAINT("exception.unique.constraint", "exception.unique.constraint.detail", HttpStatus.BAD_REQUEST),
+    PLANE_PLACE_ALREADY_TAKEN("exception.plane.place.already.taken", "exception.plane.place.already.taken.detail", HttpStatus.BAD_REQUEST);
+
+    private final String key;
+    private final String detailKey;
+    private final HttpStatus httpStatus;
+
+    Exceptions(String key, String detailKey, HttpStatus httpStatus) {
+        this.key = key;
+        this.detailKey = detailKey;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getDetail() {
+        return detailKey;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return getHttpStatus();
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/enums/PlaceStatus.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/enums/PlaceStatus.java
@@ -1,0 +1,8 @@
+package az.ingress.flightms.model.enums;
+
+public enum PlaceStatus {
+    AVAILABLE,
+    TICKET_PROCESSING,
+    RESERVED,
+    BOOKED
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/enums/PlaceType.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/enums/PlaceType.java
@@ -1,0 +1,5 @@
+package az.ingress.flightms.model.enums;
+
+public enum PlaceType {
+    NORMAL, BUSINESS, VIP
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/enums/TicketStatus.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/enums/TicketStatus.java
@@ -1,0 +1,7 @@
+package az.ingress.flightms.model.enums;
+
+public enum TicketStatus {
+    PENDING,
+    CONFIRMED,
+    REFUNDED
+}


### PR DESCRIPTION
Summary
Add the domain model for flight-ms: core entities, DTOs, mappers, and validations.

Changes

Entities: Flight, Seat, Ticket (+ enums) with JPA relations

DTOs + MapStruct mappers

Repositories and basic queries

(If used) Liquibase/Flyway migrations

Explanation
Separated model work from config to improve review clarity and document schema evolution cleanly.

Testing
Mapper and JPA repository tests; validation checks for required fields/dates.