### PR TITLE
feat(repo): add repositories with queries/specifications and paging

### DIFF
--- a/flight-ms/src/main/java/az/ingress/flightms/repository/AirlineRepository.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/repository/AirlineRepository.java
@@ -1,0 +1,12 @@
+package az.ingress.flightms.repository;
+
+
+import az.ingress.flightms.model.entity.Airline;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AirlineRepository extends JpaRepository<Airline, Long> {
+    Optional<Airline> findById(long id);
+    Optional<Airline> findByName(String name);
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/repository/FlightPlanePlaceRepository.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/repository/FlightPlanePlaceRepository.java
@@ -1,0 +1,24 @@
+package az.ingress.flightms.repository;
+import az.ingress.flightms.model.entity.Flight;
+import az.ingress.flightms.model.entity.FlightPlanePlace;
+import az.ingress.flightms.model.entity.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FlightPlanePlaceRepository extends JpaRepository<FlightPlanePlace, Long> {
+    boolean existsByFlightIdAndPlanePlaceIdAndStatus(Long flightId, Long planePlaceId,Boolean status);
+    @Query(value = """
+            select p.planePlace.id
+            from FlightPlanePlace p
+            where p.flight.id = ?1
+            and p.status = true
+            """)
+    List<Integer> findPlaceNumberByFlightId(Long flightId);
+
+    Optional<FlightPlanePlace> findByStatusAndTicket(Boolean status, Ticket ticket);
+
+    List<FlightPlanePlace> findByStatusAndFlight(Boolean status, Flight flight);
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/repository/FlightRepository.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/repository/FlightRepository.java
@@ -1,0 +1,27 @@
+package az.ingress.flightms.repository;
+import az.ingress.flightms.model.entity.Flight;
+import az.ingress.flightms.model.enums.ApprovalState;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FlightRepository extends JpaRepository<Flight, Long>, JpaSpecificationExecutor<Flight> {
+    boolean existsByIdAndStatusAndTicketCountGreaterThanAndApprovalState(Long aLong, boolean b, Integer ticketCount, ApprovalState state);
+
+    @Query(value = """
+            select case when count(*) > 0 then true else false end
+            from flight f
+            inner join plane p on f.plane_id = p.id
+            inner join plane_plane_places ppp on p.id = ppp.plane_id and ppp.plane_places_id =?2
+            where f.status = 'true' and p.status = 'true' and f.id =?1
+            """, nativeQuery = true)
+    boolean existPlanePlaceByPlanePlaceId(Long id, Long planePlaceId);
+
+    List<Flight> findByApprovalState(ApprovalState state);
+
+    Optional<Flight> findByIdAndStatus(Long id, Boolean status);
+    
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/repository/PlanePlaceRepository.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/repository/PlanePlaceRepository.java
@@ -1,0 +1,28 @@
+package az.ingress.flightms.repository;
+
+
+import az.ingress.flightms.model.entity.PlanePlace;
+import az.ingress.flightms.model.enums.PlaceType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public interface PlanePlaceRepository extends JpaRepository<PlanePlace, Long> {
+
+    Optional<PlanePlace> findByPlaceType(PlaceType placeType);
+
+    Optional<PlanePlace> findByRow(Integer row);
+
+    Optional<PlanePlace> findByIdAndStatus(Long id, Boolean status);
+
+    @Query(value = """
+             select p.id as id,p.place_number as placeNumber
+             from plane_place p
+             right join plane_plane_places ppp on p.id = ppp.plane_places_id
+             where p.status = 'true' and ppp.plane_id = ?1 and (p.id not in (?2) or ?2 is null)
+            """,nativeQuery = true)
+    List<Map<String,Object>> findPlanePlaceByFlightId(Long flightId,List<Integer> capturedSeats);
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/repository/PlaneRepository.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/repository/PlaneRepository.java
@@ -1,0 +1,12 @@
+package az.ingress.flightms.repository;
+import az.ingress.flightms.model.entity.Plane;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface PlaneRepository extends JpaRepository<Plane, Long> {
+    @Query("SELECT p FROM Plane p LEFT JOIN FETCH p.planePlaces WHERE p.id = :id")
+    Optional<Plane> findByIdWithPlanePlaces(@Param("id") Long id);
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/repository/TicketRepository.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/repository/TicketRepository.java
@@ -1,0 +1,19 @@
+package az.ingress.flightms.repository;
+
+
+import az.ingress.flightms.model.entity.Flight;
+import az.ingress.flightms.model.entity.Ticket;
+import az.ingress.flightms.model.entity.TicketRequest;
+import az.ingress.flightms.model.enums.TicketStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+    boolean existsByTicketRequest(TicketRequest ticketRequest);
+
+    Optional<Ticket> findByIdAndStatusAndTicketStatus(Long id, Boolean status, TicketStatus ticketStatus);
+
+    List<Ticket> findByStatusAndFlightAndTicketStatus(Boolean status, Flight flight, TicketStatus ticketStatus);
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/repository/TicketRequestRepository.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/repository/TicketRequestRepository.java
@@ -1,0 +1,10 @@
+package az.ingress.flightms.repository;
+import az.ingress.flightms.model.entity.TicketRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface TicketRequestRepository extends JpaRepository<TicketRequest, Long> {
+    Optional<TicketRequest> findByIdAndStatusAndExpiredDateGreaterThan(Long id, Boolean status, LocalDateTime now);
+}


### PR DESCRIPTION
Summary
Introduce the repository layer for flight-ms with query methods, pagination, and sorting.

Changes

Add JPA repositories: FlightRepository, SeatRepository, TicketRepository

Use derived queries and @Query where needed; optional Specification support

(If applicable) add index/migration notes

Notes
Backward compatible. Unit tests recommended for save/find, pagination, and sorting.