### PR TITLE
feat(service): add service layer and docker-compose flight environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,17 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: 123456
       POSTGRES_DB: user-ms
+  flight-ms-db:
+    image: postgres
+    ports:
+      - "9001:5432"
+    volumes:
+      - db_data_flight:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: 123456
+      POSTGRES_DB: flight-ms
 
 volumes:
   db_data_user: {}
+  db_data_flight: {}

--- a/flight-ms/build.gradle
+++ b/flight-ms/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     implementation group: 'org.modelmapper', name: 'modelmapper', version:'3.1.1'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    implementation 'org.liquibase:liquibase-core'
     runtimeOnly 'org.postgresql:postgresql'
 }
 

--- a/flight-ms/src/main/java/az/ingress/flightms/FlightMsApplication.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/FlightMsApplication.java
@@ -2,8 +2,10 @@ package az.ingress.flightms;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients(basePackages = "az.ingress.flightms.config.client")
 public class FlightMsApplication {
 
     public static void main(String[] args) {

--- a/flight-ms/src/main/java/az/ingress/flightms/config/client/UserClient.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/config/client/UserClient.java
@@ -1,0 +1,12 @@
+package az.ingress.flightms.config.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+
+@FeignClient(name = "userClient", url = "${user-client.url}")
+public interface UserClient {
+    @GetMapping("/info/{id}")
+    UserResponseDto getUserDetailsById(@PathVariable Long id);
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/config/client/UserResponseDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/config/client/UserResponseDto.java
@@ -1,0 +1,8 @@
+package az.ingress.flightms.config.client;
+
+public record UserResponseDto(
+        Long id,
+        String name,
+        String surname,
+        String email) {
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/mapper/Config.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/mapper/Config.java
@@ -1,0 +1,16 @@
+package az.ingress.flightms.mapper;
+
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Config {
+    @Bean
+    public ModelMapper modelMapper() {
+        ModelMapper modelMapper = new ModelMapper();
+        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+        return modelMapper;
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/mapper/FlightMapper.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/mapper/FlightMapper.java
@@ -1,0 +1,30 @@
+package az.ingress.flightms.mapper;
+
+
+import az.ingress.flightms.model.dto.FlightDto;
+import az.ingress.flightms.model.dto.request.FlightRequestDto;
+import az.ingress.flightms.model.entity.Flight;
+import az.ingress.flightms.model.enums.Airport;
+import org.mapstruct.*;
+
+@Mapper(componentModel = "spring", builder = @Builder(disableBuilder = true))
+public interface FlightMapper {
+
+    @Mapping(target = "planeDetails.id", source = "plane.id")
+    @Mapping(target = "planeDetails.name", source = "plane.name")
+    @Mapping(target = "planeDetails.capacity", source = "plane.capacity")
+    @Mapping(target = "planeDetails.planePlaces", ignore = true)
+    FlightDto toDto(Flight flight);
+
+    @Mapping(target = "plane.id", source = "planeId")
+    Flight toEntity(FlightRequestDto flightRequestDto);
+
+    @Mapping(target = "plane.id", source = "planeId")
+    void updateFlight(@MappingTarget Flight flight, FlightRequestDto flightRequestDto);
+
+    @Named("airportToString")
+    default String airportToString(Airport airport) {
+        return airport != null ? airport.name() : null;
+    }
+
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/mapper/FlightPlanePlaceMapper.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/mapper/FlightPlanePlaceMapper.java
@@ -1,0 +1,28 @@
+package az.ingress.flightms.mapper;
+import az.ingress.flightms.model.dto.request.FlightPlanePlaceDto;
+import az.ingress.flightms.model.entity.FlightPlanePlace;
+import org.mapstruct.Builder;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring", builder = @Builder(disableBuilder = true))
+public interface FlightPlanePlaceMapper {
+
+    @Mapping(source = "flight.id", target = "flightId")
+    @Mapping(source = "planePlace.id", target = "planePlaceId")
+    @Mapping(source = "ticket.id", target = "ticketId")
+    @Mapping(target = "placeStatus", source = "placeStatus")
+    FlightPlanePlaceDto toDto(FlightPlanePlace flightPlanePlace);
+
+    @Mapping(source = "flightId", target = "flight.id")
+    @Mapping(source = "planePlaceId", target = "planePlace.id")
+    @Mapping(source = "ticketId", target = "ticket.id")
+    FlightPlanePlace toEntity(FlightPlanePlaceDto dto);
+
+    @Mapping(source = "flightId", target = "flight.id")
+    @Mapping(source = "planePlaceId", target = "planePlace.id")
+    @Mapping(source = "ticketId", target = "ticket.id")
+    void updateEntity(@MappingTarget FlightPlanePlace flightPlanePlace, FlightPlanePlaceDto dto);
+
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/mapper/PlaneMapper.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/mapper/PlaneMapper.java
@@ -1,0 +1,14 @@
+package az.ingress.flightms.mapper;
+
+
+import az.ingress.flightms.model.dto.response.PlaneResponseDTO;
+import az.ingress.flightms.model.entity.Plane;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface PlaneMapper {
+
+    PlaneResponseDTO planeToPlaneResponseDTO(Plane plane);
+}
+

--- a/flight-ms/src/main/java/az/ingress/flightms/mapper/PlanePlaceMapper.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/mapper/PlanePlaceMapper.java
@@ -1,0 +1,42 @@
+package az.ingress.flightms.mapper;
+
+
+import az.ingress.flightms.model.dto.request.PlanePlaceRequest;
+import az.ingress.flightms.model.dto.response.PlanePlaceResponse;
+import az.ingress.flightms.model.entity.PlanePlace;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PlanePlaceMapper {
+
+    public PlanePlace mapToPlanePlace(PlanePlaceRequest request) {
+        PlanePlace planePlace = new PlanePlace();
+        planePlace.setPlace(request.getPlace());
+        planePlace.setPlaceNumber(request.getPlaceNumber());
+        planePlace.setPlaceType(request.getPlaceType());
+        planePlace.setRow(request.getRow());
+        return planePlace;
+
+    }
+
+
+   public PlanePlaceResponse mapToPlanePlaceToResponse(PlanePlace planePlace) {
+        PlanePlaceResponse planePlaceResponse = new PlanePlaceResponse();
+        planePlaceResponse.setPlace(planePlace.getPlace());
+        planePlaceResponse.setPlaceNumber(planePlace.getPlaceNumber());
+        planePlaceResponse.setPlaceType(planePlace.getPlaceType());
+        planePlaceResponse.setRow(planePlace.getRow());
+        planePlaceResponse.setId(planePlace.getId());
+        return planePlaceResponse;
+
+    }
+
+    public PlanePlace mapToPlanePlace(PlanePlaceResponse planePlaceResponse) {
+        PlanePlace planePlace = new PlanePlace();
+        planePlace.setPlace(planePlaceResponse.getPlace());
+        planePlace.setPlaceNumber(planePlaceResponse.getPlaceNumber());
+        planePlace.setPlaceType(planePlaceResponse.getPlaceType());
+        planePlace.setRow(planePlaceResponse.getRow());
+        return planePlace;
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/FlightDto.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/FlightDto.java
@@ -1,8 +1,8 @@
 package az.ingress.flightms.model.dto;
 
+import az.ingress.flightms.model.dto.response.PlaneResponseDTO;
+import az.ingress.flightms.model.enums.ApprovalState;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import ingress.flightms.model.dto.response.PlaneResponseDTO;
-import ingress.flightms.model.enums.ApprovalState;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/PlaneResponseDTO.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/model/dto/response/PlaneResponseDTO.java
@@ -1,6 +1,7 @@
 package az.ingress.flightms.model.dto.response;
 
-import az.ingress.flightms.model.dto.AirlineDto;
+
+import az.ingress.flightms.model.dto.request.AirlineDto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/flight-ms/src/main/java/az/ingress/flightms/service/AirlineService.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/AirlineService.java
@@ -1,0 +1,21 @@
+package az.ingress.flightms.service;
+
+
+import az.ingress.flightms.model.dto.request.AirlineDto;
+import az.ingress.flightms.model.dto.response.AirlineResponseDto;
+
+import java.util.List;
+
+public interface AirlineService {
+    AirlineResponseDto createAirline(AirlineDto airline);
+
+    AirlineResponseDto findById(long id);
+
+    List<AirlineResponseDto> findAll();
+
+    AirlineDto findByAirlineByName(String name);
+
+    AirlineResponseDto updateAirline(long id, AirlineDto airline);
+
+    void deleteAirline(long id);
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/BookingService.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/BookingService.java
@@ -1,0 +1,15 @@
+package az.ingress.flightms.service;
+import az.ingress.flightms.model.dto.response.BookingSearchResponseDto;
+import az.ingress.flightms.model.dto.response.FlightResponseDto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+
+public interface BookingService {
+    List<BookingSearchResponseDto> search(String from, String to, String date, BigDecimal price);
+
+    FlightResponseDto availableSeats(Long flightId);
+
+    void cancelFlight(Long flightId);
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/FlightPlanePlaceService.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/FlightPlanePlaceService.java
@@ -1,0 +1,16 @@
+package az.ingress.flightms.service;
+
+
+
+
+import az.ingress.flightms.model.dto.request.FlightPlanePlaceDto;
+
+import java.util.List;
+
+public interface FlightPlanePlaceService  {
+
+    FlightPlanePlaceDto getById(Long id);
+    List<FlightPlanePlaceDto> getAll();
+    FlightPlanePlaceDto update(Long id , FlightPlanePlaceDto dto);
+    void delete(Long id);
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/FlightService.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/FlightService.java
@@ -1,0 +1,29 @@
+package az.ingress.flightms.service;
+
+
+import az.ingress.flightms.model.dto.FlightDto;
+import az.ingress.flightms.model.dto.FlightDtoByCreatedOperator;
+import az.ingress.flightms.model.dto.request.FlightRequestDto;
+
+import java.util.List;
+
+public interface FlightService {
+
+    FlightDto getById(Long id);
+
+    List<FlightDto> getAll();
+
+    FlightDto create(FlightRequestDto dto);
+
+    FlightDto update(Long id, FlightRequestDto dto);
+
+    void delete(Long id);
+
+    void approveFlight(Long id, String feedback);
+
+    void rejectFlight(Long id, String feedback);
+
+    List<FlightDtoByCreatedOperator> getPendingFlightsWithOperatorDetails();
+
+    List<FlightDto> getFlightsByState(String state);
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/PlanePlaceService.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/PlanePlaceService.java
@@ -1,0 +1,23 @@
+package az.ingress.flightms.service;
+
+import az.ingress.flightms.model.dto.request.PlanePlaceRequest;
+import az.ingress.flightms.model.dto.response.PlanePlaceResponse;
+
+import java.util.Set;
+
+public interface PlanePlaceService {
+    PlanePlaceResponse createPlanePlace(PlanePlaceRequest planePlaceRequest);
+
+    PlanePlaceResponse getPlanePlaceById(Long id);
+
+    Set<PlanePlaceResponse> getAllPlanePlaces();
+
+    PlanePlaceResponse updatePlanePlace(Long id,PlanePlaceRequest planePlaceRequest);
+
+    void deletePlanePlace(Long id);
+
+    PlanePlaceResponse getPlanePlacesByType(String placeType);
+
+    PlanePlaceResponse getPlanePlacesByRow(Integer row);
+
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/PlaneService.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/PlaneService.java
@@ -1,0 +1,17 @@
+package az.ingress.flightms.service;
+
+
+import az.ingress.flightms.model.dto.request.PlaneRequestDTO;
+import az.ingress.flightms.model.dto.response.PlaneResponseDTO;
+
+import java.util.Set;
+
+public interface PlaneService {
+
+    Long createPlane(PlaneRequestDTO planeRequestDTO);
+    PlaneResponseDTO updatePlane(Long id, PlaneRequestDTO planeRequestDTO);
+    void deletePlane(Long id);
+    PlaneResponseDTO getPlane(Long id);
+    Set<PlaneResponseDTO> getAllPlanes();
+
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/TicketService.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/TicketService.java
@@ -1,0 +1,18 @@
+package az.ingress.flightms.service;
+
+import az.ingress.flightms.model.dto.request.TicketConfirmationRequestDto;
+import az.ingress.flightms.model.dto.request.TicketCreateRequestDto;
+import az.ingress.flightms.model.dto.request.TicketCreateResponseDto;
+import az.ingress.flightms.model.dto.request.TicketRequestDto;
+import az.ingress.flightms.model.dto.response.TicketConfirmationResponseDto;
+import az.ingress.flightms.model.dto.response.TicketResponseDto;
+
+public interface TicketService {
+    TicketResponseDto createTicketRequest(TicketRequestDto ticketRequestDto);
+
+    TicketCreateResponseDto createTicket(TicketCreateRequestDto ticketCreateRequestDto);
+
+    TicketConfirmationResponseDto confirm(TicketConfirmationRequestDto dto);
+
+    void refundTicket(Long ticketId);
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/impl/AirlineServiceImpl.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/impl/AirlineServiceImpl.java
@@ -1,0 +1,76 @@
+package az.ingress.flightms.service.impl;
+import az.ingress.common.model.exception.ApplicationException;
+import az.ingress.flightms.model.dto.request.AirlineDto;
+import az.ingress.flightms.model.dto.response.AirlineResponseDto;
+import az.ingress.flightms.model.entity.Airline;
+import az.ingress.flightms.model.enums.Exceptions;
+import az.ingress.flightms.repository.AirlineRepository;
+import az.ingress.flightms.service.AirlineService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.webjars.NotFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static az.ingress.flightms.model.enums.Exceptions.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AirlineServiceImpl implements AirlineService {
+    private final AirlineRepository airlineRepository;
+    private final ModelMapper modelMapper;
+
+    @Override
+    public AirlineResponseDto createAirline(AirlineDto airlineDto) {
+        Airline airline = modelMapper.map(airlineDto, Airline.class);
+        try {
+            Airline airlineNew = airlineRepository.save(airline);
+            return new AirlineResponseDto(airlineNew.getName(), airlineNew.getId());
+        } catch (Exception e) {
+            throw new ApplicationException(Exceptions.UNIQUE_CONSTRAINT, airlineDto.getName());
+        }
+    }
+
+    @Override
+    public AirlineResponseDto findById(long id) {
+        Airline airline = airlineRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Airline not found with id : " + id));
+        return modelMapper.map(airline, AirlineResponseDto.class);
+    }
+
+    @Override
+    public List<AirlineResponseDto> findAll() {
+        List<Airline> airlines = airlineRepository.findAll();
+        return airlines.stream()
+                .map(airline -> modelMapper.map(airline, AirlineResponseDto.class))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public AirlineDto findByAirlineByName(String name) {
+        Airline airline = airlineRepository.findByName(name)
+                .orElseThrow(() -> new NotFoundException("Airline not found with name : " + name));
+        return modelMapper.map(airline, AirlineDto.class);
+    }
+
+    @Override
+    public AirlineResponseDto updateAirline(long id, AirlineDto airline) {
+        Airline existingAirline = airlineRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Airline not found with id: " + id));
+        existingAirline.setName(airline.getName());
+        Airline updatedAirline = airlineRepository.save(existingAirline);
+        log.info("Airline updated with ID: {}", updatedAirline.getId());
+        return modelMapper.map(updatedAirline, AirlineResponseDto.class);
+    }
+
+    @Override
+    public void deleteAirline(long id) {
+        Airline airline = airlineRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Airline not found with id " + id));
+        airline.setStatus(false);
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/impl/BookingServiceImpl.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/impl/BookingServiceImpl.java
@@ -1,0 +1,95 @@
+package az.ingress.flightms.service.impl;
+import az.ingress.common.config.JwtSessionData;
+import az.ingress.common.model.exception.ApplicationException;
+import az.ingress.flightms.model.dto.response.BookingSearchResponseDto;
+import az.ingress.flightms.model.dto.response.FlightResponseDto;
+import az.ingress.flightms.model.entity.Flight;
+import az.ingress.flightms.model.enums.TicketStatus;
+import az.ingress.flightms.repository.FlightPlanePlaceRepository;
+import az.ingress.flightms.repository.FlightRepository;
+import az.ingress.flightms.repository.PlanePlaceRepository;
+import az.ingress.flightms.repository.TicketRepository;
+import az.ingress.flightms.service.BookingService;
+import az.ingress.flightms.specification.FlightSpecification;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static az.ingress.flightms.model.enums.Exceptions.NOT_FOUND;
+import static az.ingress.flightms.util.MapperUtil.mapDto;
+
+@Service
+@RequiredArgsConstructor
+public class BookingServiceImpl implements BookingService {
+    private static final Logger log = LoggerFactory.getLogger(BookingServiceImpl.class);
+    private final FlightSpecification flightSpecification;
+    private final FlightRepository flightRepository;
+    private final PlanePlaceRepository planePlaceRepository;
+    private final FlightPlanePlaceRepository flightPlanePlaceRepository;
+    private final TicketRepository ticketRepository;
+    private final JwtSessionData jwtSessionData;
+
+    @Override
+    public List<BookingSearchResponseDto> search(String from, String to, String date, BigDecimal price) {
+        Specification<Flight> readySpecification = flightSpecification.search(from, to, convertToDateTime(date), price);
+        List<Flight> flights = flightRepository.findAll(readySpecification);
+        List<BookingSearchResponseDto> res = new ArrayList<>(flights.size());
+        mapDto(flights, res);
+        return res;
+    }
+
+    @Override
+    public FlightResponseDto availableSeats(Long flightId) {
+        Flight flight = flightRepository.findByIdAndStatus(flightId, true).orElseThrow(() -> new ApplicationException(NOT_FOUND, Flight.class.getSimpleName()));
+        List<Integer> capturedSeats = flightPlanePlaceRepository.findPlaceNumberByFlightId(flightId);
+        List<Map<String, Object>> availableSeats = planePlaceRepository.findPlanePlaceByFlightId(flight.getPlane().getId(), capturedSeats);
+
+        return FlightResponseDto.builder()
+                .from(flight.getFrom())
+                .to(flight.getTo())
+                .price(flight.getPrice())
+                .ticketCount(flight.getTicketCount())
+                .departureTime(flight.getDepartureTime())
+                .arrivalTime(flight.getArrivalTime())
+                .availableSeats(availableSeats)
+                .build();
+    }
+
+    private LocalDateTime convertToDateTime(String date) {
+        if (date != null && !date.isEmpty()) {
+            try {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+                return LocalDateTime.parse(date, formatter);
+            } catch (DateTimeParseException e) {
+                log.error("Invalid date format: {}", date, e);
+                return null;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void cancelFlight(Long flightId) {
+        Flight flight = flightRepository.findByIdAndStatus(flightId, true).orElseThrow(() -> new ApplicationException(NOT_FOUND, Flight.class.getSimpleName()));
+        flight.setStatus(false);
+        flightPlanePlaceRepository.findByStatusAndFlight(true, flight).forEach(flightPlanePlace -> {
+            flightPlanePlace.setStatus(false);
+            flightPlanePlaceRepository.save(flightPlanePlace);
+        });
+        ticketRepository.findByStatusAndFlightAndTicketStatus(true,flight, TicketStatus.CONFIRMED).forEach(ticket -> {
+            ticket.setStatus(false);
+            ticketRepository.save(ticket);
+        });
+        flightRepository.save(flight);
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/impl/FileService.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/impl/FileService.java
@@ -1,0 +1,112 @@
+package az.ingress.flightms.service.impl;
+
+
+import az.ingress.common.model.exception.ApplicationException;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static az.ingress.flightms.model.enums.Exceptions.NOT_FOUND;
+import static az.ingress.flightms.model.enums.Exceptions.SOMETHING_WENT_WRONG;
+
+
+@Service
+public class FileService {
+    @Value("${file.directory}")
+    private String DIRECTORY_NAME;
+    @Value("${server.name}")
+    private String SERVER_NAME;
+    @Value("${server.servlet.context-path}")
+    private String CONTEXT_PATH;
+    @Value("${file.url}")
+    private String FILE_URL;
+
+
+    public String createAndWriteToFile(String example) {
+        createDirectory();
+        try {
+            Path file = Files.createFile(Path.of(System.getProperty("user.dir") + "/" + DIRECTORY_NAME + File.separator + System.currentTimeMillis() + ".txt"));
+            Files.write(file, example.getBytes());
+            return SERVER_NAME + CONTEXT_PATH + FILE_URL +"?name="+ file.toFile().getName();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new ApplicationException(SOMETHING_WENT_WRONG, example);
+        }
+    }
+
+
+    private void createDirectory() {
+        try {
+            Path dir = Path.of(System.getProperty("user.dir") + "/" + DIRECTORY_NAME);
+            if (Files.notExists(dir)) {
+                Files.createDirectory(dir);
+            }
+        } catch (Exception e) {
+            throw new ApplicationException(SOMETHING_WENT_WRONG, DIRECTORY_NAME);
+        }
+    }
+
+    public ResponseEntity<Resource> getFile(String fileName) {
+        String fileUploadPath = System.getProperty("user.dir") + DIRECTORY_NAME;
+        String[] fileNames = this.getFiles();
+        boolean contains = Arrays.asList(fileNames).contains(fileName);
+        if (!contains) {
+            throw new ApplicationException(NOT_FOUND, fileName);
+        }
+        String filePath = fileUploadPath + File.separator + fileName;
+        File file = new File(filePath);
+        try {
+            InputStreamResource resource = new InputStreamResource(new FileInputStream(file));
+            return ResponseEntity.ok()
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + resource.getFilename() + "\"")
+                    .body(resource);
+
+        } catch (Exception e) {
+            throw new ApplicationException(SOMETHING_WENT_WRONG, fileName);
+        }
+    }
+
+
+    private String[] getFiles() {
+        String folderPath = System.getProperty("user.dir") + DIRECTORY_NAME;
+        File folder = new File(folderPath);
+        String[] fileNames = folder.list();
+        return fileNames;
+    }
+    public static byte[] createPdf(String content) throws IOException {
+        PDDocument document = new PDDocument();
+        PDPage page = new PDPage();
+        document.addPage(page);
+
+        PDPageContentStream contentStream = new PDPageContentStream(document, page);
+        contentStream.setFont(PDType1Font.HELVETICA_BOLD, 12);
+        contentStream.beginText();
+        contentStream.newLineAtOffset(100, 700);
+        contentStream.showText(content);
+        contentStream.endText();
+        contentStream.close();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        document.save(outputStream);
+        document.close();
+
+        return outputStream.toByteArray();
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/impl/FlightPlanePlaceServiceImpl.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/impl/FlightPlanePlaceServiceImpl.java
@@ -1,0 +1,52 @@
+package az.ingress.flightms.service.impl;
+import az.ingress.flightms.exception.NotFoundException;
+import az.ingress.flightms.mapper.FlightPlanePlaceMapper;
+import az.ingress.flightms.model.dto.request.FlightPlanePlaceDto;
+import az.ingress.flightms.repository.FlightPlanePlaceRepository;
+import az.ingress.flightms.service.FlightPlanePlaceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static az.ingress.flightms.model.enums.Exceptions.NOT_FOUND;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class FlightPlanePlaceServiceImpl implements FlightPlanePlaceService {
+
+    private final FlightPlanePlaceRepository flightPlanePlaceRepository;
+    private final FlightPlanePlaceMapper flightPlanePlaceMapper;
+
+    @Override
+    public FlightPlanePlaceDto update(Long id, FlightPlanePlaceDto dto) {
+        var entity = flightPlanePlaceRepository.findById(id).orElseThrow(() -> new NotFoundException(NOT_FOUND));
+        flightPlanePlaceMapper.updateEntity(entity, dto);
+        return null;
+    }
+
+    @Override
+    public FlightPlanePlaceDto getById(Long id) {
+        return flightPlanePlaceRepository.findById(id)
+                .map(flightPlanePlaceMapper::toDto)
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND));
+    }
+
+    @Override
+    public List<FlightPlanePlaceDto> getAll() {
+        return flightPlanePlaceRepository.findAll().stream()
+                .map(flightPlanePlaceMapper::toDto)
+                .toList();
+    }
+
+    @Override
+    public void delete(Long id) {
+        var existedEntity = flightPlanePlaceRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND));
+        existedEntity.setStatus(false);
+        flightPlanePlaceRepository.save(existedEntity);
+    }
+
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/impl/FlightServiceImpl.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/impl/FlightServiceImpl.java
@@ -1,0 +1,190 @@
+package az.ingress.flightms.service.impl;
+import az.ingress.common.config.JwtSessionData;
+import az.ingress.flightms.config.client.UserClient;
+import az.ingress.flightms.config.client.UserResponseDto;
+import az.ingress.flightms.exception.NotFoundException;
+import az.ingress.flightms.mapper.FlightMapper;
+import az.ingress.flightms.model.dto.FlightDto;
+import az.ingress.flightms.model.dto.FlightDtoByCreatedOperator;
+import az.ingress.flightms.model.dto.request.FlightRequestDto;
+import az.ingress.flightms.model.entity.Flight;
+import az.ingress.flightms.model.entity.Plane;
+import az.ingress.flightms.model.enums.ApprovalState;
+import az.ingress.flightms.repository.FlightRepository;
+import az.ingress.flightms.repository.PlaneRepository;
+import az.ingress.flightms.service.FlightService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static az.ingress.flightms.model.enums.Exceptions.*;
+
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class FlightServiceImpl implements FlightService {
+
+    private final FlightRepository flightRepository;
+    private final PlaneRepository planeRepository;
+    private final FlightMapper flightMapper;
+    private final JwtSessionData jwtSessionData;
+    private final UserClient userClient;
+
+    @Override
+    public FlightDto getById(Long id) {
+        log.info("Fetching flight with ID: {}", id);
+        var entity = flightRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(FLIGHT_NOT_FOUND));
+        log.info("Flight found: {}", entity);
+        return flightMapper.toDto(entity);
+    }
+
+    @Override
+    public List<FlightDto> getAll() {
+        log.info("Fetching all flights");
+        List<FlightDto> flights = flightRepository.findAll().stream()
+                .map(flightMapper::toDto)
+                .toList();
+        log.info("Total flights found: {}", flights.size());
+        return flights;
+    }
+
+    @Override
+    public FlightDto create(FlightRequestDto dto) {
+        log.info("Creating flight with details: {}", dto);
+        Plane plane = planeRepository.findByIdWithPlanePlaces(dto.getPlaneId())
+                .orElseThrow(() -> new NotFoundException(PLANE_NOT_FOUND, dto.getPlaneId()));
+
+        if (plane.getPlanePlaces() == null || plane.getPlanePlaces().isEmpty()) {
+            log.warn("No PlanePlaces found for Plane with ID: {}", plane.getId());
+            throw new NotFoundException(PLANE_PLACES_NOT_FOUND, plane.getId());
+        }
+        Flight flight = flightMapper.toEntity(dto);
+        flight.setPlane(plane);
+        flight.setTicketCount(plane.getCapacity());
+        flight.setApprovalState(ApprovalState.PENDING);
+
+        var savedFlight = flightRepository.save(flight);
+        log.info("Flight created with ID: {}", savedFlight.getId());
+
+//        kafkaProducer.notifyAdminForApprovement(ADMIN_TOPIC,
+//                new AdminNotificationDto(
+//                        jwtSessionData.getUserId(),
+//                        savedFlight.getId(),
+//                        "Notification for admin for  flight approvement"));
+
+        return flightMapper.toDto(savedFlight);
+    }
+
+    @Override
+    public FlightDto update(Long id, FlightRequestDto dto) {
+        log.info("Updating flight with ID: {}", id);
+        var entity = flightRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(FLIGHT_NOT_FOUND));
+        flightMapper.updateFlight(entity, dto);
+        log.info("Flight updated: {}", entity);
+        return flightMapper.toDto(entity);
+    }
+
+    @Override
+    public void delete(Long id) {
+        log.info("Deleting flight with ID: {}", id);
+        var existedEntity = flightRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(FLIGHT_NOT_FOUND, id));
+        existedEntity.setStatus(false);
+        flightRepository.save(existedEntity);
+        log.info("Flight with ID: {} marked as status=false", id);
+    }
+
+
+    @Override
+    public void approveFlight(Long id, String feedback) {
+        log.info("Approving flight with ID: {}", id);
+        var flight = flightRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(FLIGHT_NOT_FOUND));
+        if (flight.getApprovalState() != ApprovalState.PENDING) {
+            log.error("Flight with ID: {} is not in PENDING state", id);
+            throw new IllegalStateException();
+        }
+        String feedbackMessage = feedback != null ? feedback : "No feedback provided";
+        flight.setApprovalState(ApprovalState.APPROVED);
+        flight.setFeedbackMessage(feedback);
+        flightRepository.save(flight);
+
+        var operatorDto = userClient.getUserDetailsById(flight.getCreatedBy());
+        log.info("Flight with ID: {} approved", id);
+    }
+
+    @Override
+    public void rejectFlight(Long id, String feedback) { // feedback optional
+        log.info("Rejecting flight with ID: {}", id);
+        var flight = flightRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(FLIGHT_NOT_FOUND));
+
+        if (flight.getApprovalState() != ApprovalState.PENDING) {
+            log.error("Flight with ID: {} is not in PENDING state", id);
+            throw new IllegalStateException(String.valueOf(STATE_IS_NOT_PENDING));
+        }
+        String feedbackMessage = feedback != null ? feedback : "No feedback provided";
+
+        flight.setApprovalState(ApprovalState.REJECTED);
+        flight.setFeedbackMessage(feedback);
+        flightRepository.save(flight);
+        var operatorDto = userClient.getUserDetailsById(flight.getCreatedBy());
+
+        log.info("Flight with ID: {} rejected", id);
+    }
+
+    @Override
+    public List<FlightDtoByCreatedOperator> getPendingFlightsWithOperatorDetails() {
+        log.info("Fetching flights with state PENDING");
+
+        List<Flight> flights = flightRepository.findByApprovalState(ApprovalState.PENDING);
+
+        Map<Long, UserResponseDto> operatorDetailsMap = flights.stream()
+                .map(Flight::getCreatedBy)
+                .distinct()
+                .collect(Collectors.toMap(
+                        userId -> userId,
+                        userClient::getUserDetailsById
+                ));
+
+        List<FlightDtoByCreatedOperator> flightDtoByCreatedOperators = flights.stream()
+                .map(flight -> {
+                    FlightDto flightDto = flightMapper.toDto(flight);
+                    UserResponseDto operatorDto = operatorDetailsMap.get(flight.getCreatedBy());
+
+                    return FlightDtoByCreatedOperator.builder()
+                            .operatorId(operatorDto.id())
+                            .operatorName(operatorDto.name())
+                            .operatorSurname(operatorDto.surname())
+                            .operatorEmail(operatorDto.email())
+                            .flightDto(flightDto)
+                            .build();
+                })
+                .toList();
+
+        log.info("Total flights found with state PENDING: {}", flights.size());
+
+        return flightDtoByCreatedOperators;
+    }
+
+    @Override
+    public List<FlightDto> getFlightsByState(String state) {
+        log.info("Fetching flights with state: {}", state);
+        List<FlightDto> flights = flightRepository.findByApprovalState(ApprovalState.valueOf(state.toUpperCase()))
+                .stream()
+                .map(flightMapper::toDto)
+                .toList();
+        log.info("Total flights found with state {}: {}", state, flights.size());
+        return flights;
+    }
+
+
+
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/impl/PlanePlaceServiceImpl.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/impl/PlanePlaceServiceImpl.java
@@ -1,0 +1,104 @@
+package az.ingress.flightms.service.impl;
+
+import az.ingress.flightms.mapper.PlanePlaceMapper;
+import az.ingress.flightms.model.dto.request.PlanePlaceRequest;
+import az.ingress.flightms.model.dto.response.PlanePlaceResponse;
+import az.ingress.flightms.model.entity.PlanePlace;
+import az.ingress.flightms.model.enums.PlaceType;
+import az.ingress.flightms.repository.PlanePlaceRepository;
+import az.ingress.flightms.service.PlanePlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PlanePlaceServiceImpl implements PlanePlaceService {
+
+    private final PlanePlaceRepository planePlaceRepository;
+    private final PlanePlaceMapper planePlaceMapper;
+
+    @Override
+    public PlanePlaceResponse createPlanePlace(PlanePlaceRequest planePlaceRequest) {
+
+        if (planePlaceRequest.getPlaceNumber() == null || planePlaceRequest.getPlaceType() == null) {
+            throw new IllegalArgumentException("Place number and place type are mandatory");
+        }
+
+       PlanePlaceResponse response= PlanePlaceResponse.builder()
+                .place(planePlaceRequest.getPlace())
+                .row(planePlaceRequest.getRow())
+                .placeNumber(planePlaceRequest.getPlaceNumber())
+                .placeType(planePlaceRequest.getPlaceType())
+                .build();
+
+        PlanePlace save = planePlaceRepository.save(planePlaceMapper.mapToPlanePlace(response));
+
+           return planePlaceMapper.mapToPlanePlaceToResponse(save);
+    }
+
+    @Override
+    public PlanePlaceResponse getPlanePlaceById(Long id) {
+
+        PlanePlace planePlace =planePlaceRepository.findById(id)
+                .orElseThrow(()->new RuntimeException("Not found the planePlace with id "));
+        return planePlaceMapper.mapToPlanePlaceToResponse(planePlace);
+
+
+    }
+
+    @Override
+    public Set<PlanePlaceResponse> getAllPlanePlaces() {
+       // planePlaceRepository.findAll().forEach(planePlace -> planePlaceRepository.save(planePlace));
+
+        return planePlaceRepository.findAll().stream().map(planePlaceMapper::mapToPlanePlaceToResponse)
+                .collect(Collectors.toSet());
+
+    }
+
+    @Override
+    public PlanePlaceResponse updatePlanePlace(Long id, PlanePlaceRequest planePlaceRequest) {
+
+       PlanePlace planePlace= planePlaceRepository.findById(id)
+               .orElseThrow(()->new RuntimeException("Not found the planePlace with id "));
+
+       planePlace.setPlace(planePlaceRequest.getPlace());
+       planePlace.setRow(planePlaceRequest.getRow());
+       planePlace.setPlaceNumber(planePlaceRequest.getPlaceNumber());
+       planePlace.setPlaceType(planePlaceRequest.getPlaceType());
+
+       planePlaceRepository.save(planePlace);
+
+       return planePlaceMapper.mapToPlanePlaceToResponse(planePlace);
+    }
+
+    @Override
+    public void deletePlanePlace(Long id) {
+
+        Optional<PlanePlace> planePlace = planePlaceRepository.findById(id);
+        if (planePlace.isPresent()) {
+            planePlaceRepository.delete(planePlace.get());
+        }
+
+    }
+
+    @Override
+    public PlanePlaceResponse getPlanePlacesByType(String placeType) {
+        PlanePlace planePlace= planePlaceRepository.findByPlaceType(PlaceType.valueOf(placeType))
+                .orElseThrow(()->new RuntimeException("Not found "));
+        return planePlaceMapper.mapToPlanePlaceToResponse(planePlace);
+
+    }
+
+    @Override
+    public PlanePlaceResponse getPlanePlacesByRow(Integer row) {
+        PlanePlace planePlace= planePlaceRepository.findByRow(row)
+                .orElseThrow(()->new RuntimeException("Not found "));
+        return planePlaceMapper.mapToPlanePlaceToResponse(planePlace);
+
+
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/impl/PlaneServiceImpl.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/impl/PlaneServiceImpl.java
@@ -1,0 +1,124 @@
+package az.ingress.flightms.service.impl;
+
+
+import az.ingress.flightms.exception.NotFoundException;
+import az.ingress.flightms.mapper.PlaneMapper;
+import az.ingress.flightms.model.dto.request.PlaneRequestDTO;
+import az.ingress.flightms.model.dto.response.PlaneResponseDTO;
+import az.ingress.flightms.model.entity.Airline;
+import az.ingress.flightms.model.entity.Plane;
+import az.ingress.flightms.model.entity.PlanePlace;
+import az.ingress.flightms.repository.AirlineRepository;
+import az.ingress.flightms.repository.PlanePlaceRepository;
+import az.ingress.flightms.repository.PlaneRepository;
+import az.ingress.flightms.service.PlaneService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static az.ingress.flightms.model.enums.Exceptions.NOT_FOUND;
+
+
+@Service
+@RequiredArgsConstructor
+public class PlaneServiceImpl implements PlaneService {
+
+    private final PlaneRepository planeRepository;
+    private final AirlineRepository airlineRepository;
+    private final PlanePlaceRepository planePlaceRepository;
+
+    private final PlaneMapper planeMapper;
+
+    @Override
+    public Long createPlane(PlaneRequestDTO dto) {
+
+        Airline airline = airlineRepository.findById(dto.getAirlineId()).orElseThrow(() -> new NotFoundException(NOT_FOUND, "Plane not found with ID: " + dto.getAirlineId()));
+        Set<PlanePlace> planePlace = planePlaceRepository.findAllById(dto.getPlanePlacesIds()).stream().collect(Collectors.toSet());
+
+        if (planePlace.size() != dto.getPlanePlacesIds().size()) {
+
+            Set<Long> missingIds = new HashSet<>(dto.getPlanePlacesIds());
+            missingIds.removeAll(planePlace.stream()
+                    .map(PlanePlace::getId)
+                    .collect(Collectors.toSet()));
+
+            throw new NotFoundException(NOT_FOUND,
+                    "Mismatch in PlanePlace IDs. Total requested IDs: " + dto.getPlanePlacesIds().size() +
+                            ", Found IDs: " + planePlace.size() +
+                            ". Missing IDs: " + missingIds);
+        }
+
+        Plane plane = Plane.builder()
+                .name(dto.getName())
+                .capacity(planePlace.size())
+                .airline(airline)
+                .planePlaces(planePlace)
+                .createdDate(LocalDateTime.now())
+                .status(true)
+                .build();
+
+        planeRepository.save(plane);
+
+        return plane.getId();
+    }
+
+    @Override
+    public PlaneResponseDTO updatePlane(Long id, PlaneRequestDTO dto) {
+
+        Plane plane = planeRepository.findById(id).orElseThrow(() -> new NotFoundException(NOT_FOUND, "Plane not found with ID: " + id));
+        Airline airline = airlineRepository.findById(dto.getAirlineId()).orElseThrow(() -> new NotFoundException(NOT_FOUND, "Airline not found with ID: " + dto.getAirlineId()));
+        Set<PlanePlace> planePlace = planePlaceRepository.findAllById(dto.getPlanePlacesIds()).stream().collect(Collectors.toSet());
+
+        if (planePlace.size() != dto.getPlanePlacesIds().size()) {
+
+            Set<Long> missingIds = new HashSet<>(dto.getPlanePlacesIds());
+            missingIds.removeAll(planePlace.stream()
+                    .map(PlanePlace::getId)
+                    .collect(Collectors.toSet()));
+
+            throw new NotFoundException(NOT_FOUND,
+                    "Mismatch in PlanePlace IDs. Total requested IDs: " + dto.getPlanePlacesIds().size() +
+                            ", Found IDs: " + planePlace.size() +
+                            ". Missing IDs: " + missingIds);
+        }
+
+        plane.setName(dto.getName());
+        plane.setCapacity(planePlace.size());
+        plane.setAirline(airline);
+        plane.setPlanePlaces(planePlace);
+        plane.setUpdatedDate(LocalDateTime.now());
+
+        planeRepository.save(plane);
+
+        return planeMapper.planeToPlaneResponseDTO(plane);
+    }
+
+    @Override
+    public void deletePlane(Long id) {
+
+        Optional<Plane> plane = planeRepository.findById(id);
+        plane.ifPresent(value -> value.setStatus(false));
+
+    }
+
+    @Override
+    public PlaneResponseDTO getPlane(Long id) {
+
+        Plane plane = planeRepository.findById(id).orElseThrow(() -> new NotFoundException(NOT_FOUND, "Plane not found with ID: " + id));
+        return planeMapper.planeToPlaneResponseDTO(plane);
+    }
+
+    @Override
+    public Set<PlaneResponseDTO> getAllPlanes() {
+
+        return planeRepository.findAll().stream()
+                .map(planeMapper::planeToPlaneResponseDTO)
+                .collect(Collectors.toSet());
+    }
+
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/impl/TicketServiceImpl.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/impl/TicketServiceImpl.java
@@ -1,0 +1,146 @@
+package az.ingress.flightms.service.impl;
+
+import az.ingress.common.config.JwtSessionData;
+import az.ingress.common.model.exception.ApplicationException;
+import az.ingress.flightms.model.dto.request.TicketConfirmationRequestDto;
+import az.ingress.flightms.model.dto.request.TicketCreateRequestDto;
+import az.ingress.flightms.model.dto.request.TicketCreateResponseDto;
+import az.ingress.flightms.model.dto.request.TicketRequestDto;
+import az.ingress.flightms.model.dto.response.TicketConfirmationResponseDto;
+import az.ingress.flightms.model.dto.response.TicketResponseDto;
+import az.ingress.flightms.model.entity.*;
+import az.ingress.flightms.model.enums.ApprovalState;
+import az.ingress.flightms.model.enums.PlaceStatus;
+import az.ingress.flightms.model.enums.TicketStatus;
+import az.ingress.flightms.repository.*;
+import az.ingress.flightms.service.TicketService;
+import az.ingress.flightms.util.FileUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import static az.ingress.flightms.model.enums.Exceptions.*;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TicketServiceImpl implements TicketService {
+    private final TicketRequestRepository ticketRequestRepository;
+    private final JwtSessionData jwtSessionData;
+    private final FlightPlanePlaceRepository flightPlanePlaceRepository;
+    private final FlightRepository flightRepository;
+    private final PlanePlaceRepository planePlaceRepository;
+    private final TicketRepository ticketRepository;
+    private final FileService fileService;
+
+
+    public TicketResponseDto createTicketRequest(TicketRequestDto dto) {
+
+        if (!flightRepository.existsByIdAndStatusAndTicketCountGreaterThanAndApprovalState(dto.flightId(), true,0, ApprovalState.APPROVED)) {
+            throw new ApplicationException(NOT_FOUND, Flight.class.getSimpleName());
+        }
+        if (!flightRepository.existPlanePlaceByPlanePlaceId(dto.flightId(), dto.planePlaceId())) {
+            throw new ApplicationException(NOT_FOUND, PlanePlace.class.getSimpleName());
+        }
+        if (flightPlanePlaceRepository.existsByFlightIdAndPlanePlaceIdAndStatus(dto.flightId(), dto.planePlaceId(), true)) {
+            throw new ApplicationException(PLANE_PLACE_ALREADY_TAKEN);
+        }
+
+        TicketRequest ticketRequest = new TicketRequest();
+        ticketRequest.setFlightId(dto.flightId());
+        ticketRequest.setExpiredDate(LocalDateTime.now().plusMinutes(5));
+        ticketRequest.setPlanePlaceId(dto.planePlaceId());
+        ticketRequest.setCreatedUserId(jwtSessionData.getUserId());
+        ticketRequest = ticketRequestRepository.save(ticketRequest);
+        return new TicketResponseDto(ticketRequest.getId());
+    }
+
+    @Override
+    public TicketCreateResponseDto createTicket(TicketCreateRequestDto ticketCreateRequestDto) {
+        TicketRequest ticketRequest = ticketRequestRepository.findByIdAndStatusAndExpiredDateGreaterThan(ticketCreateRequestDto.ticketRequestId(), true, LocalDateTime.now())
+                .orElseThrow(() -> new ApplicationException(NOT_FOUND, TicketRequest.class.getSimpleName()));
+
+        if (flightPlanePlaceRepository.existsByFlightIdAndPlanePlaceIdAndStatus(ticketRequest.getFlightId(), ticketRequest.getPlanePlaceId(), true)) {
+            throw new ApplicationException(PLANE_PLACE_ALREADY_TAKEN);
+        }
+
+        if (ticketRepository.existsByTicketRequest(ticketRequest)) {
+            throw new ApplicationException(TICKET_REQUEST_ALREADY_USED);
+        }
+
+        Flight flight = flightRepository.findById(ticketRequest.getFlightId()).orElseThrow(() -> new ApplicationException(NOT_FOUND, Flight.class.getSimpleName()));
+
+        Ticket ticket = Ticket.builder()
+                .flight(flight)
+                .ticketRequest(ticketRequest)
+                .boughtUserId(jwtSessionData.getUserId())
+                .ticketStatus(TicketStatus.PENDING)
+                .passengerName(ticketCreateRequestDto.passengerName())
+                .passengerSurname(ticketCreateRequestDto.passengerSurname())
+                .email(ticketCreateRequestDto.email())
+                .phone(ticketCreateRequestDto.phone())
+                .ticketNo(String.valueOf(System.currentTimeMillis()))
+                .build();
+
+        ticket = ticketRepository.save(ticket);
+
+        return new TicketCreateResponseDto(ticket.getId());
+    }
+
+    @Override
+    @Transactional
+    public TicketConfirmationResponseDto confirm(TicketConfirmationRequestDto dto) {
+        Ticket ticket = ticketRepository.findByIdAndStatusAndTicketStatus(dto.ticketId(), true,TicketStatus.PENDING).orElseThrow(() -> new ApplicationException(NOT_FOUND, Ticket.class.getSimpleName()));
+        TicketRequest ticketRequest = ticket.getTicketRequest();
+        PlanePlace planePlace = planePlaceRepository.findByIdAndStatus(ticketRequest.getPlanePlaceId(), true).orElseThrow(() -> new ApplicationException(NOT_FOUND, PlanePlace.class.getSimpleName()));
+        Flight flight = ticket.getFlight();
+        ticket.setTicketStatus(TicketStatus.CONFIRMED);
+
+        FlightPlanePlace flightPlanePlace = FlightPlanePlace.builder()
+                .planePlace(planePlace)
+                .ticket(ticket)
+                .placeStatus(PlaceStatus.BOOKED)
+                .flight(flight)
+                .build();
+
+        flightPlanePlaceRepository.save(flightPlanePlace);
+        flight.setTicketCount(flight.getTicketCount() - 1);
+
+        String ticketContent = FileUtil.createTicketExample(ticket, flightPlanePlace);
+        String ticketExampleFileUrl = fileService.createAndWriteToFile(ticketContent);
+//        kafkaProducerService.sendTicketContent(new TicketMailDto(ticketContent, jwtSessionData.getUsername(), "Ticket Confirmation"));
+        return new TicketConfirmationResponseDto(ticketExampleFileUrl);
+    }
+
+    @Override
+    @Transactional
+    public void refundTicket(Long ticketId) {
+        Ticket ticket = ticketRepository
+                .findByIdAndStatusAndTicketStatus(ticketId, true, TicketStatus.CONFIRMED)
+                .orElseThrow(() -> new ApplicationException(NOT_FOUND, Ticket.class.getSimpleName()));
+
+        if (!Objects.equals(ticket.getBoughtUserId(), jwtSessionData.getUserId())) {
+            throw new ApplicationException(UNAUTHORIZED);
+        }
+
+        if (!ticket.getFlight().getDepartureTime().isAfter(LocalDateTime.now().plusDays(1).toLocalDate().atStartOfDay())) {
+            throw new ApplicationException(TICKET_IS_NOT_REFUNDABLE);
+        }
+
+        ticket.setTicketStatus(TicketStatus.REFUNDED);
+
+        Flight flight = ticket.getFlight();
+        flight.setTicketCount(flight.getTicketCount() + 1);
+
+        flightPlanePlaceRepository
+                .findByStatusAndTicket(true,ticket)
+                .orElseThrow(() -> new ApplicationException(NOT_FOUND, FlightPlanePlace.class.getSimpleName()))
+                .setStatus(false);
+
+//        kafkaProducerService.sendTicketContent(new TicketMailDto(createRefundedTicketContent(ticket), jwtSessionData.getUsername(), "Ticket Refunded"));
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/specification/FlightSpecification.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/specification/FlightSpecification.java
@@ -1,0 +1,55 @@
+package az.ingress.flightms.specification;
+import az.ingress.flightms.model.entity.Flight;
+import az.ingress.flightms.model.enums.Airport;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.context.annotation.Scope;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Scope("prototype")
+public class FlightSpecification {
+    public Specification<Flight> search(String to, String from, LocalDateTime initialDate, BigDecimal initialPrice) {
+        return (root, query, criteriaBuilder) -> {
+            Predicate predicate = criteriaBuilder.conjunction();
+            if (from != null) {
+                List<Airport> airportsFrom = Airport.findByCity(from);
+                if (airportsFrom.isEmpty()) {
+                    airportsFrom = Airport.findByCountry(from);
+                }
+                if (!airportsFrom.isEmpty()) {
+                    CriteriaBuilder.In<String> fromAirportCodes = criteriaBuilder.in(root.get("from"));
+                    airportsFrom.forEach(airport -> fromAirportCodes.value(airport.name()));
+                    predicate = criteriaBuilder.and(predicate, fromAirportCodes);
+                } else {
+                    predicate = criteriaBuilder.and(predicate, criteriaBuilder.equal(root.get("from"), from));
+                }
+            }
+            if (to != null) {
+                List<Airport> airportsTo = Airport.findByCity(to);
+                if (airportsTo.isEmpty()) {
+                    airportsTo = Airport.findByCountry(to);
+                }
+                if (!airportsTo.isEmpty()) {
+                    CriteriaBuilder.In<String> toAirportCodes = criteriaBuilder.in(root.get("to"));
+                    airportsTo.forEach(airport -> toAirportCodes.value(airport.name()));
+                    predicate = criteriaBuilder.and(predicate, toAirportCodes);
+                } else {
+                    predicate = criteriaBuilder.and(predicate, criteriaBuilder.equal(root.get("to"), to));
+                }
+            }
+            if (initialDate != null) {
+                predicate = criteriaBuilder.and(predicate, criteriaBuilder.greaterThanOrEqualTo(root.get("departureTime"), initialDate));
+            }
+            if (initialPrice != null) {
+                predicate = criteriaBuilder.and(predicate, criteriaBuilder.greaterThanOrEqualTo(root.get("price"), initialPrice));
+            }
+            return predicate;
+        };
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/util/FileUtil.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/util/FileUtil.java
@@ -1,0 +1,61 @@
+package az.ingress.flightms.util;
+
+import az.ingress.flightms.model.entity.FlightPlanePlace;
+import az.ingress.flightms.model.entity.Ticket;
+
+import java.math.BigDecimal;
+
+public class FileUtil {
+    public static String createTicketExample(Ticket ticket, FlightPlanePlace flightPlanePlace) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Ticket No: ").append(ticket.getTicketNo()).append("\n");
+        sb.append("Passenger Name: ").append(ticket.getPassengerName()).append("\n");
+        sb.append("Passenger Surname: ").append(ticket.getPassengerSurname()).append("\n");
+        sb.append("Email: ").append(ticket.getEmail()).append("\n");
+        sb.append("Phone: ").append(ticket.getPhone()).append("\n");
+        sb.append("From: ").append(ticket.getFlight().getFrom().getCity()).append("\n");
+        sb.append("To: ").append(ticket.getFlight().getTo().getCity()).append("\n");
+        sb.append("Departure Time: ").append(ticket.getFlight().getDepartureTime()).append("\n");
+        sb.append("Arrival Time: ").append(ticket.getFlight().getArrivalTime()).append("\n");
+        sb.append("Price: ").append(ticket.getFlight().getPrice()).append("\n");
+        sb.append("Plane Place: ").append(flightPlanePlace.getPlanePlace().getPlaceNumber()).append("\n");
+        return sb.toString();
+    }
+
+    public static String createRefundedTicketContent(Ticket ticket) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Your ticket has been refunded.\n");
+        sb.append("Refunded Ticket\n");
+        sb.append("Ticket No: ").append(ticket.getTicketNo()).append("\n");
+        sb.append("Passenger Name: ").append(ticket.getPassengerName()).append("\n");
+        sb.append("Passenger Surname: ").append(ticket.getPassengerSurname()).append("\n");
+        sb.append("Email: ").append(ticket.getEmail()).append("\n");
+        sb.append("Phone: ").append(ticket.getPhone()).append("\n");
+        sb.append("From: ").append(ticket.getFlight().getFrom().getCity()).append("\n");
+        sb.append("To: ").append(ticket.getFlight().getTo().getCity()).append("\n");
+        sb.append("Departure Time: ").append(ticket.getFlight().getDepartureTime()).append("\n");
+        sb.append("Arrival Time: ").append(ticket.getFlight().getArrivalTime()).append("\n");
+        sb.append("Price: ").append(ticket.getFlight().getPrice()).append("\n");
+        sb.append("Refunded Price: ").append(ticket.getFlight().getPrice().divide(BigDecimal.valueOf(100)).multiply(BigDecimal.valueOf(50))).append("\n");
+        return sb.toString();
+    }
+    public static String createCancelFlightContent(Ticket ticket) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Flight has been canceled.\n");
+        sb.append("We are sorry to inform you that your flight has been canceled.\n");
+        sb.append("your money will be refunded.\n");
+        sb.append("Refunded Ticket\n");
+        sb.append("Ticket No: ").append(ticket.getTicketNo()).append("\n");
+        sb.append("Passenger Name: ").append(ticket.getPassengerName()).append("\n");
+        sb.append("Passenger Surname: ").append(ticket.getPassengerSurname()).append("\n");
+        sb.append("Email: ").append(ticket.getEmail()).append("\n");
+        sb.append("Phone: ").append(ticket.getPhone()).append("\n");
+        sb.append("From: ").append(ticket.getFlight().getFrom().getCity()).append("\n");
+        sb.append("To: ").append(ticket.getFlight().getTo().getCity()).append("\n");
+        sb.append("Departure Time: ").append(ticket.getFlight().getDepartureTime()).append("\n");
+        sb.append("Arrival Time: ").append(ticket.getFlight().getArrivalTime()).append("\n");
+        sb.append("Price: ").append(ticket.getFlight().getPrice()).append("\n");
+        sb.append("Refunded Price: ").append(ticket.getFlight().getPrice().divide(BigDecimal.valueOf(100)).multiply(BigDecimal.valueOf(50))).append("\n");
+        return sb.toString();
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/util/MapperUtil.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/util/MapperUtil.java
@@ -1,0 +1,22 @@
+package az.ingress.flightms.util;
+
+import az.ingress.flightms.model.dto.response.BookingSearchResponseDto;
+import az.ingress.flightms.model.entity.Flight;
+
+import java.util.List;
+
+public class MapperUtil {
+    public static void mapDto(List<Flight> flights, List<BookingSearchResponseDto> res) {
+        flights.forEach(flight -> {
+            BookingSearchResponseDto bookingSearchResponseDto = new BookingSearchResponseDto();
+            bookingSearchResponseDto.setFlightId(flight.getId());
+            bookingSearchResponseDto.setFrom((flight.getFrom() + " - " + flight.getFrom().getCity() + ", " + flight.getFrom().getCountry()));
+            bookingSearchResponseDto.setTo((flight.getTo() + " - " + flight.getTo().getCity() + ", " + flight.getTo().getCountry()));
+            bookingSearchResponseDto.setDate(flight.getDepartureTime());
+            bookingSearchResponseDto.setPrice(flight.getPrice());
+            res.add(bookingSearchResponseDto);
+        });
+    }
+
+
+}

--- a/flight-ms/src/main/resources/application-db.yaml
+++ b/flight-ms/src/main/resources/application-db.yaml
@@ -1,18 +1,14 @@
 spring:
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://127.0.0.1:9001/flight-ms?currentSchema=flight
+    url: jdbc:postgresql://localhost:9001/flight-ms?currentSchema=flight
     password: 123456
     username: postgres
   jpa:
     hibernate:
-      ddl-auto: ${DDL_AUTO:validate}
+      ddl-auto: ${DDL_AUTO:update}
     show-sql: true
     open-in-view: off
     properties:
       hibernate:
         format_sql: true
-
-  liquibase:
-    change-log: db/changelog/db.changelog-master.yaml
-    enabled: true


### PR DESCRIPTION
Summary
Introduce the service layer for flight-ms and provide a runnable Docker Compose environment for local testing.

Changes

Service interfaces & impls: FlightService, TicketService (validation, mapping, repo calls)

Transaction boundaries (@Transactional read/write)

Error handling integrated with custom exceptions

docker-compose.yml: flight-ms service + env vars (DB_URL/USER/PASSWORD/JWT_SECRET), optional Postgres