### PR TITLE
feat(controller): add REST controllers with validation & pagination

### DIFF
--- a/flight-ms/src/main/java/az/ingress/flightms/controller/AirlineController.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/controller/AirlineController.java
@@ -1,0 +1,47 @@
+package az.ingress.flightms.controller;
+
+import az.ingress.flightms.model.dto.request.AirlineDto;
+import az.ingress.flightms.model.dto.response.AirlineResponseDto;
+import az.ingress.flightms.service.AirlineService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/v1/airline")
+@RequiredArgsConstructor
+public class AirlineController {
+    private final AirlineService airlineService;
+
+    @PostMapping
+    public AirlineResponseDto createAirline(@RequestBody @Validated AirlineDto airline) {
+        return airlineService.createAirline(airline);
+    }
+
+    @GetMapping("/{id}")
+    public AirlineResponseDto findById(@PathVariable long id) {
+        return airlineService.findById(id);
+    }
+
+    @GetMapping
+    public List<AirlineResponseDto> findAll() {
+        return airlineService.findAll();
+    }
+
+    @PutMapping("{id}")
+    public AirlineResponseDto updateAirline(@PathVariable long id, @RequestBody @Validated AirlineDto airline) {
+        return airlineService.updateAirline(id, airline);
+    }
+
+    @GetMapping("/find-name/{name}")
+    public AirlineDto findByName(@PathVariable String name) {
+        return airlineService.findByAirlineByName(name);
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteAirline(@PathVariable long id) {
+        airlineService.deleteAirline(id);
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/controller/BookingController.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/controller/BookingController.java
@@ -1,0 +1,32 @@
+package az.ingress.flightms.controller;
+import az.ingress.flightms.model.dto.response.BookingSearchResponseDto;
+import az.ingress.flightms.model.dto.response.FlightResponseDto;
+import az.ingress.flightms.service.BookingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/booking")
+@RequiredArgsConstructor
+@Validated
+public class BookingController {
+    private final BookingService bookingService;
+
+    @GetMapping("/search")
+    public ResponseEntity<List<BookingSearchResponseDto>> search(
+            @RequestParam(required = false) String to,
+            @RequestParam(required = false) BigDecimal initialPrice,
+            @RequestParam(required = false) String from,
+            @RequestParam(required = false) String date) {
+        return ResponseEntity.ok(bookingService.search(to, from, date, initialPrice));
+    }
+    @GetMapping("/available-seats/{id}")
+    public ResponseEntity<FlightResponseDto> availableSeats(@PathVariable(value = "id") Long flightId) {
+        return ResponseEntity.ok(bookingService.availableSeats(flightId));
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/controller/FileController.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/controller/FileController.java
@@ -1,0 +1,20 @@
+package az.ingress.flightms.controller;
+import az.ingress.flightms.service.impl.FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/files")
+public class FileController {
+    private final FileService fileService;
+    @GetMapping
+    public ResponseEntity<Resource> testFile(@RequestParam(value = "name") String fileName){
+        return fileService.getFile(fileName);
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/controller/FlightController.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/controller/FlightController.java
@@ -1,0 +1,82 @@
+package az.ingress.flightms.controller;
+import az.ingress.flightms.model.dto.FlightDto;
+import az.ingress.flightms.model.dto.FlightDtoByCreatedOperator;
+import az.ingress.flightms.model.dto.request.FlightRequestDto;
+import az.ingress.flightms.service.BookingService;
+import az.ingress.flightms.service.FlightService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/flights")
+public class FlightController {
+
+    private final FlightService flightService;
+    private final BookingService bookingService;
+
+
+    @GetMapping("/{id}")
+    public ResponseEntity<FlightDto> getById(@PathVariable Long id) {
+        FlightDto dto = flightService.getById(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<FlightDto>> getAll() {
+        List<FlightDto> dtoList = flightService.getAll();
+        return ResponseEntity.ok(dtoList);
+    }
+    @GetMapping("/pending-approval")
+    public ResponseEntity<List<FlightDtoByCreatedOperator>> getFlightsByStateWithOperatorDetails() {
+        List<FlightDtoByCreatedOperator> dtoList = flightService.getPendingFlightsWithOperatorDetails();
+        return ResponseEntity.ok(dtoList);
+    }
+
+    @GetMapping("approval-state/{state}")
+    public ResponseEntity<List<FlightDto>> getFlightsByState(@PathVariable String state) {
+        List<FlightDto> dtoList = flightService.getFlightsByState(state);
+        return ResponseEntity.ok(dtoList);
+    }
+    @PostMapping
+    public ResponseEntity<FlightDto> create(@RequestBody @Validated FlightRequestDto dto) {
+        FlightDto createdDto = flightService.create(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdDto);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<FlightDto> update(@PathVariable Long id, @RequestBody @Validated FlightRequestDto dto) {
+        FlightDto updatedDto = flightService.update(id, dto);
+        return ResponseEntity.ok().body((updatedDto));
+    }
+
+    @PostMapping("/reject/{id}")
+    public ResponseEntity<String> reject(@PathVariable Long id, @RequestParam(required = false) String feedback) {
+        flightService.rejectFlight(id, feedback);
+        return ResponseEntity.ok().body("Flight with id " + id + " rejected" + "Email sent to operator");
+    }
+
+    @PostMapping("/approve/{id}")
+    public ResponseEntity<String> approve(@PathVariable Long id, @RequestParam(required = false) String feedback) {
+        flightService.approveFlight(id, feedback);
+        return ResponseEntity.ok().body("Flight with id " + id + " approved" + "Email sent to operator");
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        flightService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/flight/cancel/{id}")
+    public ResponseEntity<Void> cancelFlight(@PathVariable(value = "id") Long flightId) {
+        bookingService.cancelFlight(flightId);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/controller/PlaneController.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/controller/PlaneController.java
@@ -1,0 +1,50 @@
+package az.ingress.flightms.controller;
+import az.ingress.flightms.model.dto.request.PlaneRequestDTO;
+import az.ingress.flightms.model.dto.response.PlaneResponseDTO;
+import az.ingress.flightms.service.PlaneService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/v1/planes")
+@RequiredArgsConstructor
+public class PlaneController {
+
+    private final PlaneService planeService;
+
+    @GetMapping
+    public ResponseEntity<Set<PlaneResponseDTO>> getAllPlanes() {
+        Set<PlaneResponseDTO> allPlanes = planeService.getAllPlanes();
+        return ResponseEntity.ok(allPlanes);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PlaneResponseDTO> getPlaneById(@PathVariable Long id) {
+        PlaneResponseDTO plane = planeService.getPlane(id);
+        return ResponseEntity.ok(plane);
+    }
+
+    @PostMapping
+    public ResponseEntity<Long> createPlane(@RequestBody PlaneRequestDTO planeRequestDTO) {
+        Long id = planeService.createPlane(planeRequestDTO);
+        return ResponseEntity.created(URI.create("/v1/plane" + id)).body(id);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<PlaneResponseDTO> updatePlane(@PathVariable Long id, @RequestBody PlaneRequestDTO planeRequestDTO) {
+
+        PlaneResponseDTO plane = planeService.updatePlane(id, planeRequestDTO);
+        return ResponseEntity.ok(plane);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePlane(@PathVariable Long id) {
+
+        planeService.deletePlane(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/controller/PlanePlaceController.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/controller/PlanePlaceController.java
@@ -1,0 +1,41 @@
+package az.ingress.flightms.controller;
+import az.ingress.flightms.model.dto.request.PlanePlaceRequest;
+import az.ingress.flightms.model.dto.response.PlanePlaceResponse;
+import az.ingress.flightms.service.PlanePlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+
+@RestController
+@RequestMapping("api/v1/plane-place")
+@RequiredArgsConstructor
+public class PlanePlaceController {
+    private final PlanePlaceService planePlaceService;
+
+    @PostMapping
+    public ResponseEntity<PlanePlaceResponse> create(@RequestBody PlanePlaceRequest planePlaceRequest) {
+       PlanePlaceResponse planePlaceResponse= planePlaceService.createPlanePlace(planePlaceRequest);
+       return ResponseEntity.status(HttpStatus.CREATED).body(planePlaceResponse);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PlanePlaceResponse> getById(@PathVariable("id") Long id) {
+        PlanePlaceResponse planePlaceResponse= planePlaceService.getPlanePlaceById(id);
+        return ResponseEntity.ok(planePlaceResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<Set<PlanePlaceResponse>> getAll() {
+       Set<PlanePlaceResponse> planePlaceResponses=planePlaceService.getAllPlanePlaces();
+        return ResponseEntity.ok(planePlaceResponses);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<PlanePlaceResponse> update(@PathVariable Long id,@RequestBody PlanePlaceRequest planePlaceRequest) {
+       PlanePlaceResponse planePlaceResponse= planePlaceService.updatePlanePlace(id, planePlaceRequest);
+         return ResponseEntity.ok(planePlaceResponse);
+    }
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/controller/TicketController.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/controller/TicketController.java
@@ -1,0 +1,38 @@
+package az.ingress.flightms.controller;
+import az.ingress.flightms.model.dto.request.TicketConfirmationRequestDto;
+import az.ingress.flightms.model.dto.request.TicketCreateRequestDto;
+import az.ingress.flightms.model.dto.request.TicketCreateResponseDto;
+import az.ingress.flightms.model.dto.request.TicketRequestDto;
+import az.ingress.flightms.model.dto.response.TicketConfirmationResponseDto;
+import az.ingress.flightms.model.dto.response.TicketResponseDto;
+import az.ingress.flightms.service.TicketService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/tickets")
+@RequiredArgsConstructor
+public class TicketController {
+    private final TicketService ticketService;
+
+    @PostMapping("/request")
+    public ResponseEntity<TicketResponseDto> createTicketRequest(@RequestBody TicketRequestDto ticketRequestDto) {
+        return ResponseEntity.ok(ticketService.createTicketRequest(ticketRequestDto));
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<TicketCreateResponseDto> createResponseDtoResponseEntity(@RequestBody @Valid TicketCreateRequestDto ticketCreateRequestDto) {
+        return ResponseEntity.ok(ticketService.createTicket(ticketCreateRequestDto));
+    }
+    @PostMapping("/confirm")
+    public ResponseEntity<TicketConfirmationResponseDto> confirm(@RequestBody TicketConfirmationRequestDto dto){
+        return ResponseEntity.ok(ticketService.confirm(dto));
+    }
+    @GetMapping("refund/{ticketId}")
+    public ResponseEntity<Void> refundTicket(@PathVariable Long ticketId){
+        ticketService.refundTicket(ticketId);
+        return ResponseEntity.ok().build();
+    }
+}


### PR DESCRIPTION
Summary
Add REST controllers for flight-ms with request validation, pagination, and proper HTTP semantics.

Changes

Controllers: Airline, Booking, File, Flight, Plane, PlanePlace, Ticket

Request/Response DTOs, basic mapping to services

201 Created with Location, 200 OK, 204 No Content; pageable endpoints

Notes
Delegates to service layer; errors handled by global exception handler. No secrets included.