### PR TITLE
added kafka model and config

### DIFF
--- a/common/src/main/java/az/ingress/common/kafka/AdminNotification.java
+++ b/common/src/main/java/az/ingress/common/kafka/AdminNotification.java
@@ -1,0 +1,4 @@
+package az.ingress.common.kafka;
+
+public record AdminNotification(Long id) {
+}

--- a/common/src/main/java/az/ingress/common/kafka/AdminNotificationDto.java
+++ b/common/src/main/java/az/ingress/common/kafka/AdminNotificationDto.java
@@ -1,0 +1,7 @@
+package az.ingress.common.kafka;
+
+public record AdminNotificationDto(
+        Long operatorId,
+        Long flightId,
+        String subject) {
+}

--- a/common/src/main/java/az/ingress/common/kafka/OperatorNotification.java
+++ b/common/src/main/java/az/ingress/common/kafka/OperatorNotification.java
@@ -1,0 +1,3 @@
+package az.ingress.common.kafka;
+
+public record OperatorNotification(Long flightId, String approvalState, String comments) {}

--- a/common/src/main/java/az/ingress/common/kafka/OperatorNotificationDto.java
+++ b/common/src/main/java/az/ingress/common/kafka/OperatorNotificationDto.java
@@ -1,0 +1,11 @@
+package az.ingress.common.kafka;
+
+public record OperatorNotificationDto(
+        Long flightId,
+        String operatorEmail,
+        String operatorName,
+        String operatorSurname,
+        String approvalState,
+        String subject,
+        String feedbackMessage) {
+}

--- a/common/src/main/java/az/ingress/common/kafka/OperatorRegisterDto.java
+++ b/common/src/main/java/az/ingress/common/kafka/OperatorRegisterDto.java
@@ -1,0 +1,6 @@
+package az.ingress.common.kafka;
+
+import java.util.List;
+
+public record OperatorRegisterDto(String email, String firstName, String lastName, List<String> adminEmails) {
+}

--- a/common/src/main/java/az/ingress/common/kafka/UserRegisterDto.java
+++ b/common/src/main/java/az/ingress/common/kafka/UserRegisterDto.java
@@ -1,0 +1,4 @@
+package az.ingress.common.kafka;
+
+public record UserRegisterDto(String email, String firstName, String lastName, String token) {
+}

--- a/common/src/main/java/az/ingress/common/kafka/UserResetPasswordDto.java
+++ b/common/src/main/java/az/ingress/common/kafka/UserResetPasswordDto.java
@@ -1,0 +1,4 @@
+package az.ingress.common.kafka;
+
+public record UserResetPasswordDto(String email, String firstName, String lastName, String token) {
+}

--- a/kafka/docker-compose.yaml
+++ b/kafka/docker-compose.yaml
@@ -1,0 +1,24 @@
+services:
+  kafdrop:
+    image: obsidiandynamics/kafdrop
+    restart: "unless-stopped"
+    ports:
+      - "9000:9000"
+    environment:
+      KAFKA_BROKERCONNECT: "kafka:29092"
+    depends_on:
+      - kafka
+  kafka:
+    image: obsidiandynamics/kafka
+    restart: "unless-stopped"
+    ports:
+      - "2181:2181"
+      - "9092:9092"
+    environment:
+      KAFKA_LISTENERS: "INTERNAL://kafka:29092, EXTERNAL://0.0.0.0:9092"
+      KAFKA_ADVERTISED_LISTENERS: "INTERNAL://kafka:29092, EXTERNAL://localhost:9092"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT, EXTERNAL:PLAINTEXT"
+      KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
+      KAFKA_ZOOKEEPER_SESSION_TIMEOUT: "6000"
+      ZOOKEEPER_AUTOPURGE_PURGE_INTERNAL: "9"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"

--- a/notification-ms/src/main/java/az/ingress/notificationms/config/BeanConfig.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/config/BeanConfig.java
@@ -1,0 +1,18 @@
+package az.ingress.notificationms.config;
+import az.ingress.common.config.JwtSessionData;
+import az.ingress.common.model.exception.Handler;
+import az.ingress.common.service.JwtService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+
+@Configuration
+@Import({Handler.class, JwtService.class})
+public class BeanConfig {
+    @Bean
+    public JwtSessionData jwtSessionData() {
+        return new JwtSessionData();
+    }
+
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/config/JwtAuthenticationService.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/config/JwtAuthenticationService.java
@@ -1,0 +1,68 @@
+package az.ingress.notificationms.config;
+import az.ingress.common.config.JwtSessionData;
+import az.ingress.common.service.JwtService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationService extends OncePerRequestFilter {
+    private final JwtService jwtService;
+    private final JwtSessionData jwtSessionData;
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String header = request.getHeader("Authorization");
+            if (header != null && header.startsWith("Bearer ")){
+                String token = header.substring(7);
+                Jws<Claims> claimsJws = jwtService.parseToken(token);
+                Authentication authentication = getAuthentication(claimsJws.getPayload(), response);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }else{
+                jwtSessionData.setUserId(0L);
+                jwtSessionData.setUsername("anonymous");
+                jwtSessionData.setRole("anonymous");
+            }
+            filterChain.doFilter(request, response);
+        } catch (JwtException | BadCredentialsException ex){
+            SecurityContextHolder.clearContext();
+            throw new InsufficientAuthenticationException("Invalid JWT", ex);
+        }
+    }
+
+    private Authentication getAuthentication(Claims claims, HttpServletResponse response){
+        try {
+            String username = claims.get("username", String.class);
+            String role = claims.get("role", String.class);
+            Long userId = claims.get("userId", Long.class);
+
+            jwtSessionData.setUsername(username);
+            jwtSessionData.setRole(role);
+            jwtSessionData.setUserId(userId);
+
+            var authorities = List.of(new SimpleGrantedAuthority(role));
+            return new UsernamePasswordAuthenticationToken(username, null, authorities);
+        } catch (Exception e) {
+            throw new BadCredentialsException("Invalid token", e);
+        }
+    }
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/config/KafkaConsumerConfig.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/config/KafkaConsumerConfig.java
@@ -1,0 +1,120 @@
+package az.ingress.notificationms.config;
+import az.ingress.common.kafka.*;
+import az.ingress.common.model.dto.TicketMailDto;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import java.util.HashMap;
+import java.util.Map;
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Bean
+    public ConsumerFactory<String, OperatorRegisterDto> consumerFactoryForOperatorRegister() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaListenerContainerFactory<?> kafkaListenerContainerFactoryForOperatorRegister() {
+        ConcurrentKafkaListenerContainerFactory<String, OperatorRegisterDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactoryForOperatorRegister());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, UserResetPasswordDto> consumerFactoryForResetPassword() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaListenerContainerFactory<?> kafkaListenerContainerFactoryForResetPassword() {
+        ConcurrentKafkaListenerContainerFactory<String, UserResetPasswordDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactoryForResetPassword());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, UserRegisterDto> consumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaListenerContainerFactory<?> kafkaListenerContainerFactoryForUserRegister() {
+        ConcurrentKafkaListenerContainerFactory<String, UserRegisterDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+    @Bean
+    public ConsumerFactory<String, TicketMailDto> consumerFactoryForTicketCreate() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaListenerContainerFactory<?> kafkaListenerContainerFactoryForTicketCreate() {
+        ConcurrentKafkaListenerContainerFactory<String, TicketMailDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactoryForTicketCreate());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, AdminNotificationDto> consumerFactoryForAdminNotification() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaListenerContainerFactory<?> kafkaListenerContainerFactoryForAdminNotification() {
+        ConcurrentKafkaListenerContainerFactory<String, AdminNotificationDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactoryForAdminNotification());
+        return factory;
+    }
+
+
+    @Bean
+    public ConsumerFactory<String, OperatorNotificationDto> consumerFactoryForOperatorNotification() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaListenerContainerFactory<?> kafkaListenerContainerFactoryForOperatorNotification() {
+        ConcurrentKafkaListenerContainerFactory<String, OperatorNotificationDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactoryForOperatorNotification());
+        return factory;
+    }
+
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/config/KafkaProducerConfig.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/config/KafkaProducerConfig.java
@@ -1,0 +1,31 @@
+package az.ingress.notificationms.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, Object> producerObjectFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplateObject() {
+        return new KafkaTemplate<>(producerObjectFactory());
+    }
+
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/config/SecurityConfig.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package az.ingress.notificationms.config;
+import az.ingress.common.model.constant.EndPoints;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtAuthenticationService jwtAuthenticationService;
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity security) throws Exception {
+        security
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(
+                                EndPoints.SWAGGER_V2,
+                                EndPoints.SWAGGER_V3,
+                                EndPoints.SWAGGER_V3_ALL,
+                                EndPoints.SWAGGER_RESOURCE,
+                                EndPoints.SWAGGER_RESOURCE_ALL,
+                                EndPoints.SWAGGER_CONFIGURATION_UI,
+                                EndPoints.SWAGGER_CONFIGURATION_SECURITY,
+                                EndPoints.SWAGGER_UI,
+                                EndPoints.SWAGGER_WEBJARS,
+                                EndPoints.SWAGGER_UI_HTML).permitAll()
+                        .requestMatchers("/api/v1/notifications/**").hasAuthority("ADMIN")
+                        .anyRequest().authenticated())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(jwtAuthenticationService, UsernamePasswordAuthenticationFilter.class);
+        return security.build();
+    }
+}


### PR DESCRIPTION
Option 1
Add Notifications config and Kafka message model (topic constants + payload DTO + serializer settings). Config-only; no business logic changes.

Option 2
Introduce notification configuration and Kafka model for publish/consume (topic name, message schema, serialization). App boots with new settings.

Option 3
Notifications: add config files and Kafka model (DTO + topic config). Prepares service for sending/receiving messages; no runtime behavior changed yet.

Option 4
Set up notification configs and Kafka artifacts (message model, topic keys, serializers). Verified local startup.