### PR TITLE
added notication - ms

### DIFF
--- a/notification-ms/src/main/java/az/ingress/notificationms/controller/NotificationController.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/controller/NotificationController.java
@@ -1,0 +1,29 @@
+package az.ingress.notificationms.controller;
+import az.ingress.notificationms.model.dto.NotificationResponseDto;
+import az.ingress.notificationms.service.listener.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping("/by-state")
+    public ResponseEntity<List<NotificationResponseDto>> getNotificationsByState(@RequestParam(defaultValue = "UNREAD") String state) {
+        List<NotificationResponseDto> notifications = notificationService.getNotificationsByState(state);
+        return ResponseEntity.ok(notifications);
+    }
+
+    @PutMapping("/mark-as-read")
+    public ResponseEntity<Void> markAsRead(@RequestBody List<Long> ids) {
+        notificationService.markAsRead(ids);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/listener/AuthServiceListener.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/listener/AuthServiceListener.java
@@ -1,0 +1,35 @@
+package az.ingress.notificationms.listener;
+
+import az.ingress.common.kafka.UserRegisterDto;
+import az.ingress.notificationms.service.listener.UserRegisterListenerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.DltHandler;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthServiceListener {
+    private final UserRegisterListenerService userRegisterListenerService;
+    @RetryableTopic(
+            attempts = "3",
+            autoCreateTopics = "true",
+            backoff = @Backoff(delay = 1000L, multiplier = 3),
+            dltTopicSuffix = "MY_DLT",
+            retryTopicSuffix = "MY_RETRY",
+            autoStartDltHandler = "true"
+    )
+    @KafkaListener(topics = "user-registration", groupId = "user-register-notification",containerFactory = "kafkaListenerContainerFactoryForUserRegister")
+    public void listenUserRegister(UserRegisterDto dto){
+        log.info("User register event received: {}", dto);
+        userRegisterListenerService.sendNotification(dto);
+    }
+    @DltHandler
+    public void dltListen(String failedMessage) {
+        System.err.println("Failed message from dlt listen: " + failedMessage);
+    }
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/listener/BookingListener.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/listener/BookingListener.java
@@ -1,0 +1,38 @@
+package az.ingress.notificationms.listener;
+import az.ingress.common.model.dto.TicketMailDto;
+import az.ingress.notificationms.service.listener.impl.TicketCreateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.DltHandler;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BookingListener {
+    private final TicketCreateService ticketCreateService;
+
+    @RetryableTopic(
+            attempts = "3",
+            autoCreateTopics = "true",
+            backoff = @Backoff(delay = 1000L, multiplier = 3),
+            dltTopicSuffix = "MY_DLT",
+            retryTopicSuffix = "MY_RETRY",
+            autoStartDltHandler = "true"
+    )
+    @KafkaListener(topics = "ticket-create",
+            groupId = "ticket-create-group",
+            containerFactory = "kafkaListenerContainerFactoryForTicketCreate")
+    public void listenUserRegister(TicketMailDto dto) {
+        log.info("User register event received: {}", dto);
+        ticketCreateService.sendNotification(dto);
+    }
+
+    @DltHandler
+    public void dltListen(String failedMessage) {
+        System.err.println("Failed message in ticket-create from dlt listen: " + failedMessage);
+    }
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/listener/FlightService.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/listener/FlightService.java
@@ -1,0 +1,49 @@
+package az.ingress.notificationms.listener;
+import az.ingress.common.kafka.AdminNotificationDto;
+import az.ingress.common.kafka.OperatorNotificationDto;
+import az.ingress.notificationms.service.listener.AdminEmailService;
+import az.ingress.notificationms.service.listener.OperatorEmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FlightService {
+    private final AdminEmailService adminEmailService;
+    private final OperatorEmailService operatorEmailService;
+
+    @RetryableTopic(
+            attempts = "3",
+            autoCreateTopics = "true",
+            backoff = @Backoff(delay = 1000L, multiplier = 3),
+            dltTopicSuffix = "MY_DLT",
+            retryTopicSuffix = "MY_RETRY",
+            autoStartDltHandler = "true"
+    )
+    @KafkaListener(topics = "admin-notification", groupId = "admin-notification-group", containerFactory = "kafkaListenerContainerFactoryForAdminNotification")
+    public void listenAdminApproval(AdminNotificationDto dto) {
+        log.info("Admin notification event received: {}", dto);
+        adminEmailService.sendNotification(dto);
+    }
+
+    @RetryableTopic(
+            attempts = "3",
+            autoCreateTopics = "true",
+            backoff = @Backoff(delay = 1000L, multiplier = 3),
+            dltTopicSuffix = "MY_DLT",
+            retryTopicSuffix = "MY_RETRY",
+            autoStartDltHandler = "true"
+    )
+    @KafkaListener(topics = "operator-notification", groupId = "operator-notification-group", containerFactory = "kafkaListenerContainerFactoryForOperatorNotification")
+    public void listenOperatorInform(OperatorNotificationDto dto) {
+        log.info("Operator notification event received: {}", dto);
+        operatorEmailService.sendNotification(dto);
+    }
+
+
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/listener/OperatorRegisterServiceListener.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/listener/OperatorRegisterServiceListener.java
@@ -1,0 +1,32 @@
+package az.ingress.notificationms.listener;
+import az.ingress.common.kafka.OperatorRegisterDto;
+import az.ingress.notificationms.service.listener.impl.OperatorRegisterListenerServiceImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OperatorRegisterServiceListener {
+
+    private final OperatorRegisterListenerServiceImpl operatorRegisterListenerService;
+
+    @RetryableTopic(
+            attempts = "3",
+            autoCreateTopics = "true",
+            backoff = @Backoff(delay = 1000L, multiplier = 3),
+            dltTopicSuffix = "MY_DLT",
+            retryTopicSuffix = "MY_RETRY",
+            autoStartDltHandler = "true"
+    )
+    @KafkaListener(topics = "operator-register", groupId = "operator-register-notification", containerFactory = "kafkaListenerContainerFactoryForOperatorRegister")
+    public void listen(OperatorRegisterDto operatorRegisterDto) {
+
+        operatorRegisterListenerService.sendNotificationApp(operatorRegisterDto);
+        operatorRegisterListenerService.sendNotificationEmail(operatorRegisterDto);
+    }
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/listener/PasswordResetServiceListener.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/listener/PasswordResetServiceListener.java
@@ -1,0 +1,30 @@
+package az.ingress.notificationms.listener;
+
+import az.ingress.common.kafka.UserResetPasswordDto;
+import az.ingress.notificationms.service.listener.PasswordResetEmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PasswordResetServiceListener {
+    private final PasswordResetEmailService passwordResetEmailService;
+    @RetryableTopic(
+            attempts = "3",
+            autoCreateTopics = "true",
+            backoff = @Backoff(delay = 1000L, multiplier = 3),
+            dltTopicSuffix = "MY_DLT",
+            retryTopicSuffix = "MY_RETRY",
+            autoStartDltHandler = "true"
+    )
+    @KafkaListener(topics = "reset-password", groupId = "reset-password-notification",containerFactory = "kafkaListenerContainerFactoryForResetPassword")
+    public void listenResetPassword(UserResetPasswordDto dto){
+        log.info("Reset Password event received: {}", dto);
+        passwordResetEmailService.sendEmail(dto);
+    }
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/mapper/NotificationMapper.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/mapper/NotificationMapper.java
@@ -1,0 +1,11 @@
+package az.ingress.notificationms.mapper;
+import az.ingress.common.kafka.OperatorRegisterDto;
+import az.ingress.notificationms.model.dto.NotificationResponseDto;
+import az.ingress.notificationms.model.entity.Notification;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface NotificationMapper {
+    NotificationResponseDto notificationToResponseDto(Notification notification);
+    Notification dtoToEntity(OperatorRegisterDto dto);
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/model/dto/NotificationResponseDto.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/model/dto/NotificationResponseDto.java
@@ -1,0 +1,7 @@
+package az.ingress.notificationms.model.dto;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponseDto(Long id, String message, LocalDateTime time){
+
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/model/entity/Notification.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/model/entity/Notification.java
@@ -1,0 +1,34 @@
+package az.ingress.notificationms.model.entity;
+import az.ingress.notificationms.model.enums.NotificationState;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity(name = "notifications")
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "entity_seq")
+    @SequenceGenerator(name = "entity_seq", sequenceName = "entity_seq", allocationSize = 1)
+    private Long id;
+
+    @Column(nullable = false, length = 2000)
+    private String message;
+
+    private LocalDateTime sentAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationState state;
+
+    private LocalDateTime createDate;
+
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/model/enums/Exceptions.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/model/enums/Exceptions.java
@@ -1,0 +1,29 @@
+package az.ingress.notificationms.model.enums;
+import az.ingress.common.model.exception.AbstractException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+@Getter
+public enum Exceptions implements AbstractException {
+    NOT_FOUND("exception.not.found","exception.not.found.detail", HttpStatus.NOT_FOUND),
+    APPLICATION_MAIL_MESSAGE_FAILURE("exception.application.mail.message.failure", "exception.application.mail.message.failure.detail", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String key;
+    private final String detailKey;
+    private final HttpStatus httpStatus;
+
+    Exceptions(String key, String detailKey, HttpStatus httpStatus) {
+        this.key = key;
+        this.detailKey = detailKey;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getDetail() {
+        return detailKey;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return getHttpStatus();
+    }
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/model/enums/NotificationState.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/model/enums/NotificationState.java
@@ -1,0 +1,6 @@
+package az.ingress.notificationms.model.enums;
+
+public enum NotificationState {
+    READ,
+    UNREAD
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/repository/NotificationRepository.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/repository/NotificationRepository.java
@@ -1,0 +1,14 @@
+package az.ingress.notificationms.repository;
+
+
+import az.ingress.notificationms.model.entity.Notification;
+import az.ingress.notificationms.model.enums.NotificationState;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    Optional<List<Notification>> findAllByIdIn(List<Long> ids);
+    Optional<List<Notification>> findAllByState(NotificationState status);
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/MailService.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/MailService.java
@@ -1,0 +1,5 @@
+package az.ingress.notificationms.service;
+
+public interface MailService {
+    void sendMail(String to, String subject, String text);
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/impl/MailServiceImpl.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/impl/MailServiceImpl.java
@@ -1,0 +1,34 @@
+package az.ingress.notificationms.service.impl;
+
+import az.ingress.common.model.exception.ApplicationException;
+import az.ingress.notificationms.service.MailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import static az.ingress.notificationms.model.enums.Exceptions.APPLICATION_MAIL_MESSAGE_FAILURE;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MailServiceImpl implements MailService {
+    private final JavaMailSender javaMailSender;
+
+    @Override
+    public void sendMail(String to, String subject, String text) {
+        try {
+            log.info("Sending mail to: {} subject {}, text {}", to, subject, text);
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(to);
+            message.setSubject(subject);
+            message.setText(text);
+            javaMailSender.send(message);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new ApplicationException(APPLICATION_MAIL_MESSAGE_FAILURE, text);
+        }
+    }
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/AdminEmailService.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/AdminEmailService.java
@@ -1,0 +1,8 @@
+package az.ingress.notificationms.service.listener;
+
+
+import az.ingress.common.kafka.AdminNotificationDto;
+
+public interface AdminEmailService {
+    void sendNotification(AdminNotificationDto adminNotificationDto);
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/NotificationService.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/NotificationService.java
@@ -1,0 +1,14 @@
+package az.ingress.notificationms.service.listener;
+
+
+import az.ingress.notificationms.model.dto.NotificationResponseDto;
+
+import java.util.List;
+
+public interface NotificationService {
+
+    List<NotificationResponseDto> getNotificationsByState(String state);
+
+    void markAsRead(List<Long> ids);
+
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/OperatorEmailService.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/OperatorEmailService.java
@@ -1,0 +1,8 @@
+package az.ingress.notificationms.service.listener;
+
+
+import az.ingress.common.kafka.OperatorNotificationDto;
+
+public interface OperatorEmailService {
+    void sendNotification(OperatorNotificationDto operatorNotificationDto);
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/OperatorRegisterListenerService.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/OperatorRegisterListenerService.java
@@ -1,0 +1,10 @@
+package az.ingress.notificationms.service.listener;
+
+
+import az.ingress.common.kafka.OperatorRegisterDto;
+
+public interface OperatorRegisterListenerService {
+    void sendNotificationEmail(OperatorRegisterDto operatorRegisterDto);
+
+    void sendNotificationApp(OperatorRegisterDto operatorRegisterDto);
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/PasswordResetEmailService.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/PasswordResetEmailService.java
@@ -1,0 +1,8 @@
+package az.ingress.notificationms.service.listener;
+
+
+import az.ingress.common.kafka.UserResetPasswordDto;
+
+public interface PasswordResetEmailService {
+    void sendEmail(UserResetPasswordDto dto);
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/UserRegisterListenerService.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/UserRegisterListenerService.java
@@ -1,0 +1,8 @@
+package az.ingress.notificationms.service.listener;
+
+
+import az.ingress.common.kafka.UserRegisterDto;
+
+public interface UserRegisterListenerService {
+    void sendNotification(UserRegisterDto dto);
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/AdminEmailServiceImpl.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/AdminEmailServiceImpl.java
@@ -1,0 +1,46 @@
+package az.ingress.notificationms.service.listener.impl;
+
+import az.ingress.common.kafka.AdminNotificationDto;
+import az.ingress.notificationms.service.MailService;
+import az.ingress.notificationms.service.listener.AdminEmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminEmailServiceImpl implements AdminEmailService {
+
+    private final MailService mailService;
+
+    @Override
+    public void sendNotification(AdminNotificationDto adminNotificationDto) {
+        String rejectLink = "http://localhost:8081/flight-ms/flights/reject/" + adminNotificationDto.flightId();
+        String approveLink = "http://localhost:8081/flight-ms/flights/approve/" + adminNotificationDto.flightId();
+        String checkLink = "http://localhost:8081/flight-ms/flights/" + adminNotificationDto.flightId();
+
+        String message = String.format(
+                """
+                        Dear Admin Adminov,\s
+
+                        New flight(%s) created by operator(%s).
+
+                        You can approve or reject the flight. If you want to check the flight status, enter the link below:
+                        %s
+
+                        To approve, click here: %s
+
+                        To reject, click here: %s
+
+                        Best regards,
+                        The Flight Application Team""",
+                adminNotificationDto.flightId(),
+                adminNotificationDto.operatorId(),
+                checkLink,
+                approveLink,
+                rejectLink
+        );
+        mailService.sendMail("2004osm94@gmail.com", adminNotificationDto.subject(), message); //admin
+    }
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/NotificationServiceImpl.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/NotificationServiceImpl.java
@@ -1,0 +1,50 @@
+package az.ingress.notificationms.service.listener.impl;
+import az.ingress.common.model.exception.ApplicationException;
+import az.ingress.notificationms.mapper.NotificationMapper;
+import az.ingress.notificationms.model.dto.NotificationResponseDto;
+import az.ingress.notificationms.model.entity.Notification;
+import az.ingress.notificationms.model.enums.NotificationState;
+import az.ingress.notificationms.repository.NotificationRepository;
+import az.ingress.notificationms.service.listener.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static az.ingress.notificationms.model.enums.Exceptions.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationMapper notificationMapper;
+
+    @Override
+    public List<NotificationResponseDto> getNotificationsByState(String state) {
+
+        List<Notification> notifications = notificationRepository.findAllByState(NotificationState.valueOf(state.toUpperCase())).orElseThrow(() -> new ApplicationException(NOT_FOUND));
+
+        notifications.forEach(notification -> notification.setSentAt(LocalDateTime.now()));
+
+        List<NotificationResponseDto> list = notifications.stream()
+                .map(notificationMapper::notificationToResponseDto)
+                .toList();
+
+        notificationRepository.saveAll(notifications);
+
+        return list;
+    }
+
+    @Override
+    public void markAsRead(List<Long> ids) {
+
+        List<Notification> notifications = notificationRepository.findAllByIdIn(ids).orElseThrow(() -> new ApplicationException(NOT_FOUND));
+
+        notifications.forEach(notification -> {
+            notification.setState(NotificationState.READ);
+        });
+        notificationRepository.saveAll(notifications);
+    }
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/OperatorEmailServiceImpl.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/OperatorEmailServiceImpl.java
@@ -1,0 +1,42 @@
+package az.ingress.notificationms.service.listener.impl;
+
+import az.ingress.common.kafka.OperatorNotificationDto;
+import az.ingress.notificationms.service.MailService;
+import az.ingress.notificationms.service.listener.OperatorEmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OperatorEmailServiceImpl implements OperatorEmailService {
+
+    private final MailService mailService;
+
+
+    @Override
+    public void sendNotification(OperatorNotificationDto operatorNotificationDto) {
+        String checkLink = "http://localhost:8081/flight-ms/flights/" + operatorNotificationDto.flightId();
+        String message = String.format("""
+                        Dear operator %s %s,\s
+
+                        %s
+
+                        Feedback: %s
+                        
+                        If you want to check the flight status, enter the link below: %s
+                        
+                        Best regards,
+                        The Flight Application Team
+                        """,
+                operatorNotificationDto.operatorName(),
+                operatorNotificationDto.operatorSurname(),
+                operatorNotificationDto.subject(),
+                operatorNotificationDto.feedbackMessage(),
+                checkLink
+        );
+        mailService.sendMail(operatorNotificationDto.operatorEmail(), operatorNotificationDto.subject(), message);
+
+    }
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/OperatorRegisterListenerServiceImpl.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/OperatorRegisterListenerServiceImpl.java
@@ -1,0 +1,58 @@
+package az.ingress.notificationms.service.listener.impl;
+import az.ingress.common.kafka.OperatorRegisterDto;
+import az.ingress.notificationms.model.entity.Notification;
+import az.ingress.notificationms.model.enums.NotificationState;
+import az.ingress.notificationms.repository.NotificationRepository;
+import az.ingress.notificationms.service.MailService;
+import az.ingress.notificationms.service.listener.OperatorRegisterListenerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class OperatorRegisterListenerServiceImpl implements OperatorRegisterListenerService {
+
+    private final MailService mailService;
+    private final NotificationRepository notificationRepository;
+
+    private static final String SUBJECT = "User register for Operator";
+
+    @Override
+    public void sendNotificationEmail(OperatorRegisterDto operatorRegisterDto) {
+        String link = "http://localhost:8083/api/v1/operators/admin/operator/approval";
+        String message = "Dear Admin,\n\n" +
+                "A new operator registration request has been made. Below are the details of the operator:\n\n" +
+                "First Name: " + operatorRegisterDto.firstName() + "\n" +
+                "Last Name: " + operatorRegisterDto.lastName() + "\n" +
+                "Email: " + operatorRegisterDto.email() + "\n\n" +
+                "To approve this request and assign the operator role, please click the link below:\n\n" +
+                link + "\n\n" +
+                "If you did not initiate this request, please disregard this email.\n\n" +
+                "Best regards,\n" +
+                "The Flight Application Team";
+        operatorRegisterDto.adminEmails().forEach(adminEmail -> mailService.sendMail( adminEmail, SUBJECT, message));
+    }
+
+    @Override
+    public void sendNotificationApp(OperatorRegisterDto operatorRegisterDto) {
+
+        String notificationMessage = "A new operator registration request has been made.\n\n" +
+                "Details of the operator:\n" +
+                "First Name: " + operatorRegisterDto.firstName() + "\n" +
+                "Last Name: " + operatorRegisterDto.lastName() + "\n" +
+                "Email: " + operatorRegisterDto.email() + "\n\n" +
+                "Please review and approve the request if necessary.";
+
+
+        Notification notification = Notification.builder()
+                .message(notificationMessage)
+                .state(NotificationState.UNREAD)
+                .createDate(LocalDateTime.now())
+                .build();
+
+        notificationRepository.save(notification);
+    }
+
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/PasswordResetEmailServiceImpl.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/PasswordResetEmailServiceImpl.java
@@ -1,0 +1,30 @@
+package az.ingress.notificationms.service.listener.impl;
+
+import az.ingress.common.kafka.UserResetPasswordDto;
+import az.ingress.notificationms.service.MailService;
+import az.ingress.notificationms.service.listener.PasswordResetEmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PasswordResetEmailServiceImpl implements PasswordResetEmailService {
+
+    private final MailService mailService;
+
+    private static final String SUBJECT = "Verification for password reset";
+
+    @Override
+    public void sendEmail(UserResetPasswordDto dto) {
+        String link = "http://localhost:8083/api/v1/auth/password/reset?token=" + dto.token();
+        String message = "Dear " + dto.firstName() + " " + dto.lastName() + ",\n\n" +
+                "If you did not request a password reset, please disregard this email.\n\n" +
+                "We received a request to reset your password. To reset your password, please click the link below:\n\n" +
+                link + "\n\n" +
+                "Best regards,\n" +
+                "The Flight Application Team";
+        mailService.sendMail(dto.email(), SUBJECT, message);
+    }
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/TicketCreateService.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/TicketCreateService.java
@@ -1,0 +1,14 @@
+package az.ingress.notificationms.service.listener.impl;
+import az.ingress.common.model.dto.TicketMailDto;
+import az.ingress.notificationms.service.MailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TicketCreateService {
+    private final MailService mailService;
+    public void sendNotification(TicketMailDto dto) {
+        mailService.sendMail(dto.getEmail(), dto.getSubject(), dto.getTicketContent());
+    }
+}

--- a/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/UserRegisterListenerServiceImpl.java
+++ b/notification-ms/src/main/java/az/ingress/notificationms/service/listener/impl/UserRegisterListenerServiceImpl.java
@@ -1,0 +1,19 @@
+package az.ingress.notificationms.service.listener.impl;
+import az.ingress.common.kafka.UserRegisterDto;
+import az.ingress.notificationms.service.MailService;
+import az.ingress.notificationms.service.listener.UserRegisterListenerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserRegisterListenerServiceImpl implements UserRegisterListenerService {
+    private final MailService mailService;
+
+    @Override
+    public void sendNotification(UserRegisterDto dto) {
+        String link = "http://localhost:8083/api/v1/auth/verify?token=" + dto.token();
+        String message = "Welcome to our platform. Thank you for registering " + dto.firstName() + " " + dto.lastName() + ". Please verify your email. Please click the link below\n " + link;
+        mailService.sendMail(dto.email(), "flight application register service", message);
+    }
+}

--- a/notification-ms/src/main/resources/messages.properties
+++ b/notification-ms/src/main/resources/messages.properties
@@ -1,0 +1,4 @@
+exception.application.mail.message.failure=message sending failed
+exception.application.mail.message.failure.detail=The message could not be sent. Please try again later.
+exception.not.found=Not found
+exception.not.found.detail=Not found {0}

--- a/notification-ms/src/main/resources/messages_az.properties
+++ b/notification-ms/src/main/resources/messages_az.properties
@@ -1,0 +1,4 @@
+exception.application.mail.message.failure=mesaj göndərilmədi
+exception.application.mail.message.failure.detail=Mesaj göndərilmədi. Zəhmət olmasa daha sonra yenidən cəhd edin.
+exception.not.found=Tapılmadı
+exception.not.found.detail={0} tapılmadı

--- a/notification-ms/src/main/resources/messages_ru.properties
+++ b/notification-ms/src/main/resources/messages_ru.properties
@@ -1,0 +1,4 @@
+exception.application.mail.message.failure=сообщение не отправлено
+exception.application.mail.message.failure.detail=Сообщение не отправлено. Пожалуйста, попробуйте позже.
+exception.not.found=не найдено
+exception.not.found.detail={0} не найдено


### PR DESCRIPTION
Option 1
feat(notification-ms): bootstrap service
Add Notifications microservice with base structure: config, controller, listener, mapper, model, repository, service, and NotificationMsApplication. Includes YAML configs (db/email) and Kafka message model. Builds & starts; minimal logic.

Option 2
Initial commit: Notifications service
Create module skeleton (configs, controller, listener, mapper, model, repo, service). Add DB/Email YAMLs and Kafka DTO/topic setup. No business logic yet.

Option 3
Notifications MS scaffolding
Introduce project structure and configs, plus Kafka model for messaging. Ready for wiring handlers; behavior to follow in next PRs.

Option 4
Add notifications-ms (structure + configs + Kafka)
Folders: config/controller/listener/mapper/model/repository/service. Add application*.yaml and Kafka payload/topic definitions. Compile-only change.