### PR TITLE
 kafka integrate other services

### DIFF
--- a/flight-ms/src/main/java/az/ingress/flightms/producer/KafkaProducer.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/producer/KafkaProducer.java
@@ -1,0 +1,26 @@
+package az.ingress.flightms.producer;
+import az.ingress.common.kafka.AdminNotificationDto;
+import az.ingress.common.kafka.OperatorNotificationDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaProducer {
+    private final KafkaTemplate<String, AdminNotificationDto> adminNotificationTemplate;
+    private final KafkaTemplate<String, OperatorNotificationDto> operatorNotificationTemplate;
+
+    public void notifyAdminForApprovement(String topic, AdminNotificationDto createdFlightId) {
+        adminNotificationTemplate.send(topic, createdFlightId);
+        log.info("Flight {} sent for admin for approval", createdFlightId);
+    }
+
+    public void notifyOperator(String topic, OperatorNotificationDto notification) {
+        operatorNotificationTemplate.send(topic, notification);
+        log.info("Notification sent to operator {}", notification);
+    }
+
+}

--- a/flight-ms/src/main/java/az/ingress/flightms/service/impl/PlanePlaceServiceImpl.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/impl/PlanePlaceServiceImpl.java
@@ -52,7 +52,6 @@ public class PlanePlaceServiceImpl implements PlanePlaceService {
 
     @Override
     public Set<PlanePlaceResponse> getAllPlanePlaces() {
-       // planePlaceRepository.findAll().forEach(planePlace -> planePlaceRepository.save(planePlace));
 
         return planePlaceRepository.findAll().stream().map(planePlaceMapper::mapToPlanePlaceToResponse)
                 .collect(Collectors.toSet());

--- a/flight-ms/src/main/java/az/ingress/flightms/service/impl/PlaneServiceImpl.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/impl/PlaneServiceImpl.java
@@ -31,7 +31,6 @@ public class PlaneServiceImpl implements PlaneService {
     private final PlaneRepository planeRepository;
     private final AirlineRepository airlineRepository;
     private final PlanePlaceRepository planePlaceRepository;
-
     private final PlaneMapper planeMapper;
 
     @Override

--- a/flight-ms/src/main/java/az/ingress/flightms/service/kafka/KafkaProducerService.java
+++ b/flight-ms/src/main/java/az/ingress/flightms/service/kafka/KafkaProducerService.java
@@ -1,0 +1,15 @@
+package az.ingress.flightms.service.kafka;
+
+import az.ingress.common.model.dto.TicketMailDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaProducerService {
+    private final KafkaTemplate<String, TicketMailDto> kafkaTemplate;
+    public void sendTicketContent(TicketMailDto message) {
+        kafkaTemplate.send("ticket-create", message);
+    }
+}


### PR DESCRIPTION
Option 1
Integrate Kafka across services: add producers/consumers, shared message model, and topic/config wiring. No breaking changes.

Option 2
Enable inter-service messaging via Kafka (publish/consume). Added topic configs and DTOs; services now emit/handle events.

Option 3
Kafka integration for other services: configured topics, serializers, and basic producers/consumers to support event-driven flow.